### PR TITLE
DSPDC-956 Fix specification of release_history table.

### DIFF
--- a/schema/src/main/jade-tables/release_history.table.json
+++ b/schema/src/main/jade-tables/release_history.table.json
@@ -8,8 +8,12 @@
     },
     {
       "name": "archive_path",
-      "datatype": "file_ref",
+      "datatype": "fileref",
       "type": "required"
     }
-  ]
+  ],
+  "partitioning": {
+    "mode": "date_from_column",
+    "column": "release_date"
+  }
 }


### PR DESCRIPTION
Noticed the table was missing from the schema while I was prepping an example for HCA.