### PR TITLE
QH - DSPDC-804 - Stage a release_history object in GCS

### DIFF
--- a/orchestration/templates/create-json-object.yaml
+++ b/orchestration/templates/create-json-object.yaml
@@ -17,4 +17,4 @@ spec:
         source: |
             json='{"release_date":"'{{ "{{inputs.parameters.release-date}}" }}'","archive_path":"'{{ "{{inputs.parameters.archive-path}}" }}'"}'
             echo "$json" > release_history.json
-            gsutil -m rsync -r /state/release_history.json {{ "{{inputs.parameters.upload-path}}" }}
+            gsutil -m cp /state/release_history.json {{ "{{inputs.parameters.upload-path}}" }}

--- a/orchestration/templates/create-json-object.yaml
+++ b/orchestration/templates/create-json-object.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: create-json-object
+spec:
+  templates:
+    - name: main
+      inputs:
+        parameters:
+          - name: pvc-name
+          - name: release-date # release date (store to json object)
+          - name: archive-path # archive path (store to json object)
+          - name: upload-path # upload to this gs: path
+      volumes:
+        - name: state
+          persistentVolumeClaim:
+            claimName: '{{ "{{inputs.parameters.pvc-name}}" }}'
+            readOnly: true
+      {{- include "argo.retry" . | indent 6 }}
+      script:
+        image: google/cloud-sdk:slim
+        command: [bash]
+        source: |
+        json='{"@release_date":"'{{ "{{inputs.parameters.release-date}}" }}'","@archive_path":"'{{ "{{inputs.parameters.archive-path}}" }}'"}'
+        echo "$json" > release_history.json
+      container:
+        image: google/cloud-sdk:slim
+        command: [gsutil]
+        args:
+          - -m
+          - rsync
+          - -r
+          - /state/release_history.json
+          - {{ "{{inputs.parameters.upload-path}}" }} # upload the file to this path
+        volumeMounts:
+          - name: state
+            mountPath: /state
+            readOnly: true

--- a/orchestration/templates/create-json-object.yaml
+++ b/orchestration/templates/create-json-object.yaml
@@ -15,10 +15,6 @@ spec:
         image: google/cloud-sdk:slim
         command: [bash]
         source: |
-        json='{"release_date":"'{{ "{{inputs.parameters.release-date}}" }}'","archive_path":"'{{ "{{inputs.parameters.archive-path}}" }}'"}'
-        echo "$json" > release_history.json
-        gsutil -m rsync -r /state/release_history.json {{ "{{inputs.parameters.upload-path}}" }}
-        volumeMounts:
-          - name: state
-            mountPath: /state
-            readOnly: true
+            json='{"release_date":"'{{ "{{inputs.parameters.release-date}}" }}'","archive_path":"'{{ "{{inputs.parameters.archive-path}}" }}'"}'
+            echo "$json" > release_history.json
+            gsutil -m rsync -r /state/release_history.json {{ "{{inputs.parameters.upload-path}}" }}

--- a/orchestration/templates/create-json-object.yaml
+++ b/orchestration/templates/create-json-object.yaml
@@ -7,31 +7,17 @@ spec:
     - name: main
       inputs:
         parameters:
-          - name: pvc-name
-          - name: release-date # release date (store to json object)
-          - name: archive-path # archive path (store to json object)
-          - name: upload-path # upload to this gs: path
-      volumes:
-        - name: state
-          persistentVolumeClaim:
-            claimName: '{{ "{{inputs.parameters.pvc-name}}" }}'
-            readOnly: true
+          - name: release-date
+          - name: archive-path
+          - name: upload-path
       {{- include "argo.retry" . | indent 6 }}
       script:
         image: google/cloud-sdk:slim
         command: [bash]
         source: |
-        json='{"@release_date":"'{{ "{{inputs.parameters.release-date}}" }}'","@archive_path":"'{{ "{{inputs.parameters.archive-path}}" }}'"}'
+        json='{"release_date":"'{{ "{{inputs.parameters.release-date}}" }}'","archive_path":"'{{ "{{inputs.parameters.archive-path}}" }}'"}'
         echo "$json" > release_history.json
-      container:
-        image: google/cloud-sdk:slim
-        command: [gsutil]
-        args:
-          - -m
-          - rsync
-          - -r
-          - /state/release_history.json
-          - {{ "{{inputs.parameters.upload-path}}" }} # upload the file to this path
+        gsutil -m rsync -r /state/release_history.json {{ "{{inputs.parameters.upload-path}}" }}
         volumeMounts:
           - name: state
             mountPath: /state

--- a/orchestration/templates/create-json-object.yaml
+++ b/orchestration/templates/create-json-object.yaml
@@ -17,4 +17,4 @@ spec:
         source: |
             json='{"release_date":"'{{ "{{inputs.parameters.release-date}}" }}'","archive_path":"'{{ "{{inputs.parameters.archive-path}}" }}'"}'
             echo "$json" > release_history.json
-            gsutil -m cp /state/release_history.json {{ "{{inputs.parameters.upload-path}}" }}
+            gsutil -m cp release_history.json {{ "{{inputs.parameters.upload-path}}" }}

--- a/orchestration/templates/ingest-clinvar-archive.yaml
+++ b/orchestration/templates/ingest-clinvar-archive.yaml
@@ -129,7 +129,7 @@ spec:
             arguments:
               parameters:
                 - name: release-date
-                  value: '{{ "/{{tasks.extract-release-date.outputs.result}}.xml" }}'
+                  value: '{{ "{{tasks.extract-release-date.outputs.result}}" }}'
                 - name: archive-path
                   value: '{{ printf "gs://%s/{{inputs.parameters.gcs-prefix}}/raw/%s" .Values.gcs.bucketName $localXmlName }}'
                 - name: upload-path

--- a/orchestration/templates/ingest-clinvar-archive.yaml
+++ b/orchestration/templates/ingest-clinvar-archive.yaml
@@ -128,8 +128,6 @@ spec:
               template: main
             arguments:
               parameters:
-                - name: pvc-name
-                  value: '{{ $extractionPvc }}'
                 - name: release-date
                   value: '{{ "/{{tasks.extract-release-date.outputs.result}}.xml" }}'
                 - name: archive-path

--- a/orchestration/templates/ingest-clinvar-archive.yaml
+++ b/orchestration/templates/ingest-clinvar-archive.yaml
@@ -122,7 +122,7 @@ spec:
                   value: 'ClinVarVariationRelease/part-1.json'
           # 6) Stage a release_history object in GCS
           - name: stage-release-history
-            dependencies: [extract-release-date]
+            dependencies: [upload-raw-archive, extract-release-date]
             templateRef:
               name: create-json-object
               template: main

--- a/orchestration/templates/ingest-clinvar-archive.yaml
+++ b/orchestration/templates/ingest-clinvar-archive.yaml
@@ -120,7 +120,23 @@ spec:
                   value: '{{ $extractionPvc }}'
                 - name: file-path
                   value: 'ClinVarVariationRelease/part-1.json'
-          # 6) Run Dataflow on uploaded JSON.
+          # 6) Stage a release_history object in GCS
+          - name: stage-release-history
+            dependencies: [extract-release-date]
+            templateRef:
+              name: create-json-object
+              template: main
+            arguments:
+              parameters:
+                - name: pvc-name
+                  value: '{{ $extractionPvc }}'
+                - name: release-date
+                  value: '{{ "/{{tasks.extract-release-date.outputs.result}}.xml" }}'
+                - name: archive-path
+                  value: '{{ printf "gs://%s/{{inputs.parameters.gcs-prefix}}/raw/%s" .Values.gcs.bucketName $localXmlName }}'
+                - name: upload-path
+                  value: '{{ printf "gs://%s/{{inputs.parameters.gcs-prefix}}/processed/release_history/" .Values.gcs.bucketName }}'
+          #  7) Run Dataflow on uploaded JSON.
           - name: process-archive
             dependencies: [upload-extracted-archive]
             templateRef:
@@ -134,7 +150,7 @@ spec:
                   value: '{{ "{{inputs.parameters.gcs-prefix}}" }}/raw'
                 - name: output-prefix
                   value: '{{ "{{inputs.parameters.gcs-prefix}}" }}/processed'
-          # 7) Diff generated data against existing data
+          # 8) Diff generated data against existing data
           - name: diff-tables
             dependencies: [process-archive]
             templateRef:

--- a/orchestration/templates/ingest-clinvar-archive.yaml
+++ b/orchestration/templates/ingest-clinvar-archive.yaml
@@ -122,7 +122,7 @@ spec:
                   value: 'ClinVarVariationRelease/part-1.json'
           # 6) Stage a release_history object in GCS
           - name: stage-release-history
-            dependencies: [upload-raw-archive, extract-release-date]
+            dependencies: [extract-release-date]
             templateRef:
               name: create-json-object
               template: main


### PR DESCRIPTION
Added a new template - create-json-object to save release date and archive path (provided as params) to a json file and then rsnyc the file to the provided upload path.
Need to confirm that this is working as expected.