### PR TITLE
QH - DSPDC-1028 - Bumping sbtPluginsVersion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,7 @@
 import _root_.io.circe.Json
-import org.broadinstitute.monster.sbt.model.JadeIdentifier
 
 lazy val `clinvar-ingest` = project
-  .in(file("."))
+.in(file("."))
   .aggregate(`clinvar-schema`, `clinvar-transformation-pipeline`)
   .settings(publish / skip := true)
 
@@ -10,10 +9,6 @@ lazy val `clinvar-schema` = project
   .in(file("schema"))
   .enablePlugins(MonsterJadeDatasetPlugin)
   .settings(
-    jadeDatasetName := JadeIdentifier
-      .fromString("broad_dsp_clinvar")
-      .fold(sys.error, identity),
-    jadeDatasetDescription := "Mirror of NCBI's ClinVar archive, maintained by Broad's Data Sciences Platform",
     jadeTablePackage := "org.broadinstitute.monster.clinvar.jadeschema.table",
     jadeStructPackage := "org.broadinstitute.monster.clinvar.jadeschema.struct"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import _root_.io.circe.Json
 
 lazy val `clinvar-ingest` = project
-.in(file("."))
+  .in(file("."))
   .aggregate(`clinvar-schema`, `clinvar-transformation-pipeline`)
   .settings(publish / skip := true)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-val sbtPluginsVersion = "0.20.0"
+val sbtPluginsVersion = "0.23.0"
 
 val patternBase =
   "org/broadinstitute/monster/[module](_[scalaVersion])(_[sbtVersion])/[revision]"


### PR DESCRIPTION
Updating the sbtPluginsVersion to match the most recent monster-sbt-plugins release.
Updating build.sbt to reflect Raaid's downstream changes in DSPDC-1067.
Pipeline tests completed successfully.