### PR TITLE
DSPDC-908 Create a snapshot at the end of the workflow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import _root_.io.circe.Json
 
 lazy val `clinvar-ingest` = project
   .in(file("."))
-  .aggregate(`clinvar-schema`, `clinvar-transformation-pipeline`)
+  .aggregate(`clinvar-schema`, `clinvar-transformation-pipeline`, `clinvar-orchestration-workflow`)
   .settings(publish / skip := true)
 
 lazy val `clinvar-schema` = project
@@ -10,6 +10,7 @@ lazy val `clinvar-schema` = project
   .enablePlugins(MonsterJadeDatasetPlugin)
   .settings(
     jadeTablePackage := "org.broadinstitute.monster.clinvar.jadeschema.table",
+    jadeTableFragmentPackage := "org.broadinstitute.monster.clinvar.jadeschema.fragment",
     jadeStructPackage := "org.broadinstitute.monster.clinvar.jadeschema.struct"
   )
 

--- a/orchestration/example-values/no-version.yaml
+++ b/orchestration/example-values/no-version.yaml
@@ -1,6 +1,24 @@
-gcs:
-  bucketName: buk
-  resultBucketName: buc
+staging:
+  gcsBucket: buk
+  bigquery:
+    project: project
+    datasetPrefix: monster_staging_data
+    description: ClinVar!!!
+    expiration: '604800'
+jade:
+  url: http://jade.repo
+  datasetId: a
+  datasetName: clinvar
+  profileId: b
+  dataProject: dataaaaa
+  accessKey:
+    secretName: dont-tell
+    secretKey: its-a-secret
+clingen:
+  gcsBucket: buc
+  kafka:
+    topic: foo
+    secretName: bar
 serviceAccount:
   k8sName: k8sss
   googleName: goog@boog
@@ -12,27 +30,8 @@ dataflow:
   subnetName: network
   workerAccount: runner@zoog
   useFlexRS: false
-bigquery:
-  stagingData:
-    project: project
-    datasetPrefix: monster_staging_data
-    description: ClinVar!!!
-    expiration: '604800'
-  jadeData:
-    project: dataaaaaa
-    dataset: clinvar
-repo:
-  url: http://jade.repo
-  datasetId: a
-  profileId: b
-  accessKey:
-    secretName: dont-tell
-    secretKey: its-a-secret
 notification:
   onlyOnFailure: false
   slackUrl:
     secretName: aaaaa
     secretKey: bbbbb
-kafka:
-  topic: foo
-  secretName: bar

--- a/orchestration/example-values/pinned-version.yaml
+++ b/orchestration/example-values/pinned-version.yaml
@@ -1,6 +1,24 @@
-gcs:
-  bucketName: buk
-  resultBucketName: buc
+staging:
+  gcsBucket: buk
+  bigquery:
+    project: project
+    datasetPrefix: monster_staging_data
+    description: ClinVar!!!
+    expiration: '604800'
+jade:
+  url: http://jade.repo
+  datasetId: a
+  datasetName: clinvar
+  profileId: b
+  dataProject: dataaaaa
+  accessKey:
+    secretName: dont-tell
+    secretKey: its-a-secret
+clingen:
+  gcsBucket: buc
+  kafka:
+    topic: foo
+    secretName: bar
 serviceAccount:
   k8sName: k8sss
   googleName: goog@boog
@@ -12,22 +30,6 @@ dataflow:
   subnetName: network
   workerAccount: runner@zoog
   useFlexRS: false
-bigquery:
-  stagingData:
-    project: project
-    datasetPrefix: monster_staging_data
-    description: ClinVar!!!
-    expiration: '604800'
-  jadeData:
-    project: dataaaaaa
-    dataset: clinvar
-repo:
-  url: http://jade.repo
-  datasetId: a
-  profileId: b
-  accessKey:
-    secretName: dont-tell
-    secretKey: its-a-secret
 argoTemplates:
   diffBQTable:
     schemaImageVersion: adsaasdf
@@ -36,6 +38,3 @@ notification:
   slackUrl:
     secretName: aaaaa
     secretKey: bbbbb
-kafka:
-  topic: foo
-  secretName: bar

--- a/orchestration/scripts/poll-ingest-job.py
+++ b/orchestration/scripts/poll-ingest-job.py
@@ -1,0 +1,52 @@
+import google.auth
+from google.auth.transport.requests import AuthorizedSession
+from requests.exceptions import HTTPError
+import polling
+import os
+import random
+import sys
+
+credentials, project = google.auth.default(scopes=['openid', 'email', 'profile'])
+
+base_url = os.environ["API_URL"]
+job_id = os.environ["JOB_ID"]
+timeout = os.environ["TIMEOUT"]
+
+authed_session = AuthorizedSession(credentials)
+
+
+def check_job_status(job_id: str):
+    response = authed_session.get(f"{base_url}/api/repository/v1/jobs/{job_id}")
+    if response.ok:
+        return response.json()["job_status"]
+    else:
+        raise HTTPError("Bad response, got code of: {}".format(response.status_code))
+
+
+def is_done(job_id: str) -> bool:
+    # if "running" then we want to keep polling, so false
+    # if "succeeded" then we want to stop polling, so true
+    # if "failed" then we want to stop polling, so true
+    status = check_job_status(job_id)
+    return status in ["succeeded", "failed"]
+
+
+def is_success(job_id: str):
+    # need to spit out the lowercase strings instead of real bools, allows the workflow to know if it succeeded or not
+    if check_job_status(job_id) == "succeeded":
+        return "true"
+    else:
+        raise ValueError("Job ran but did not succeed.")
+
+
+def step_function(step: int) -> int:
+    return random.randint(step, step + 10)
+
+
+try:
+    polling.poll(lambda: is_done(job_id), step=10, step_function=step_function, timeout=int(timeout))
+    print(is_success(job_id))
+except polling.TimeoutException as te:
+    while not te.values.empty():
+        # Print all of the values that did not meet the exception
+        print(te.values.get(), file=sys.stderr)

--- a/orchestration/scripts/request-full-view-snapshot.py
+++ b/orchestration/scripts/request-full-view-snapshot.py
@@ -1,0 +1,30 @@
+import google.auth
+from google.auth.transport.requests import AuthorizedSession
+from requests.exceptions import HTTPError
+import os
+import random
+import sys
+
+credentials, project = google.auth.default(scopes=['openid', 'email', 'profile'])
+
+base_url = os.environ["API_URL"]
+dataset_name = os.environ["DATASET_NAME"]
+profile_id = os.environ["PROFILE_ID"]
+snapshot_name = os.environ["SNAPSHOT_NAME"]
+
+authed_session = AuthorizedSession(credentials)
+
+
+def submit_snapshot(**kwargs):
+  response = authed_session.post(f'{base_url}/api/repository/v1/snapshots', json=kwargs)
+  if response.ok:
+    return response.json()['id']
+  else:
+    raise HTTPError(f'Bad response, got code of: {response.status_code}')
+
+snapshot_contents = [{
+  'datasetName': dataset_name,
+  'mode': 'byFullView'
+}]
+
+print(submit_snapshot(contents=snapshot_contents, name=snapshot_name, profileId=profile_id))

--- a/orchestration/scripts/request-full-view-snapshot.py
+++ b/orchestration/scripts/request-full-view-snapshot.py
@@ -11,6 +11,7 @@ base_url = os.environ["API_URL"]
 dataset_name = os.environ["DATASET_NAME"]
 profile_id = os.environ["PROFILE_ID"]
 snapshot_name = os.environ["SNAPSHOT_NAME"]
+snapshot_description = os.environ["SNAPSHOT_DESCRIPTION"]
 
 authed_session = AuthorizedSession(credentials)
 
@@ -27,4 +28,5 @@ snapshot_contents = [{
   'mode': 'byFullView'
 }]
 
-print(submit_snapshot(contents=snapshot_contents, name=snapshot_name, profileId=profile_id))
+print(submit_snapshot(
+  contents=snapshot_contents, name=snapshot_name, profileId=profile_id, description=snapshot_description))

--- a/orchestration/templates/cron-workflow.yaml
+++ b/orchestration/templates/cron-workflow.yaml
@@ -31,8 +31,10 @@ spec:
                   - name: archive-path
                     value: weekly_release/ClinVarVariationRelease_00-latest_weekly.xml.gz
                   - name: gcs-prefix
-                    value: '{{ template "argo.timestamp" }}'
+                    value: {{ include "argo.timestamp" . | quote }}
                   - name: notify-clingen
+                    value: 'true'
+                  - name: publish-snapshot
                     value: 'true'
 
       ##
@@ -43,7 +45,7 @@ spec:
         steps:
           - - name: send-notification
               template: send-slack-notification
-              when: '{{ "{{workflow.status}} != Succeeded" }}'
+              when: {{ "{{workflow.status}} != Succeeded" | quote }}
 
       ##
       ## Send a Slack notification describing the final status of the workflow.
@@ -53,9 +55,9 @@ spec:
           image: curlimages/curl:7.70.0
           env:
             - name: WORKFLOW_ID
-              value: '{{ "{{workflow.name}}" }}'
+              value: {{ "{{workflow.name}}" | quote }}
             - name: WORKFLOW_STATE
-              value: '{{ "{{workflow.status}}" }}'
+              value: {{ "{{workflow.status}}" | quote }}
             - name: SLACK_URL
               valueFrom:
                 secretKeyRef:

--- a/orchestration/templates/ingest-clinvar-archive.yaml
+++ b/orchestration/templates/ingest-clinvar-archive.yaml
@@ -67,4 +67,14 @@ spec:
                   value: {{ $notifyClingen | quote }}
                 - name: publish-snapshot
                   value: {{ $publishSnapshot | quote }}
-            {{- $ingestSummary := "{{tasks.ingest-processed-archive.outputs.parameters.summary}}" }}
+
+          - name: snapshot-dataset
+            dependencies: [ingest-raw-archive, ingest-processed-archive]
+            when: {{ printf "%s == true" $publishSnapshot | quote }}
+            templateRef:
+              name: snapshot-dataset
+              template: main
+            arguments:
+              parameters:
+                - name: release-date
+                  value: {{ $releaseDate | quote }}

--- a/orchestration/templates/ingest-clinvar-archive.yaml
+++ b/orchestration/templates/ingest-clinvar-archive.yaml
@@ -21,6 +21,8 @@ spec:
           {{- $gcsPrefix := "{{inputs.parameters.gcs-prefix}}" }}
           - name: notify-clingen
           {{- $notifyClingen := "{{inputs.parameters.notify-clingen}}" }}
+          - name: publish-snapshot
+          {{- $publishSnapshot := "{{inputs.parameters.publish-snapshot}}" }}
       dag:
         tasks:
           # Transfer and process the archive, staging outputs in GCS.
@@ -31,9 +33,9 @@ spec:
             arguments:
               parameters:
                 - name: archive-path
-                  value: '{{ $archivePath }}'
+                  value: {{ $archivePath | quote }}
                 - name: gcs-prefix
-                  value: '{{ $gcsPrefix }}'
+                  value: {{ $gcsPrefix | quote }}
             {{- $releaseDate := "{{tasks.process-archive.outputs.parameters.release-date}}" }}
 
           # Ingest the raw archive into the Repository, for provenance.
@@ -45,9 +47,9 @@ spec:
             arguments:
               parameters:
                 - name: gcs-prefix
-                  value: '{{ $gcsPrefix }}'
+                  value: {{ $gcsPrefix | quote }}
                 - name: release-date
-                  value: '{{ $releaseDate }}'
+                  value: {{ $releaseDate | quote }}
 
           # Ingest the processed archive into the Repository.
           - name: ingest-processed-archive
@@ -58,9 +60,11 @@ spec:
             arguments:
               parameters:
                 - name: gcs-prefix
-                  value: '{{ $gcsPrefix }}'
+                  value: {{ $gcsPrefix | quote }}
                 - name: release-date
-                  value: '{{ $releaseDate }}'
+                  value: {{ $releaseDate | quote }}
                 - name: publish-kafka
-                  value: '{{ $notifyClingen }}'
+                  value: {{ $notifyClingen | quote }}
+                - name: publish-snapshot
+                  value: {{ $publishSnapshot | quote }}
             {{- $ingestSummary := "{{tasks.ingest-processed-archive.outputs.parameters.summary}}" }}

--- a/orchestration/templates/ingest-processed-archive.yaml
+++ b/orchestration/templates/ingest-processed-archive.yaml
@@ -21,8 +21,6 @@ spec:
           {{- $releaseDate := "{{inputs.parameters.release-date}}" }}
           - name: publish-kafka
           {{- $publishKafka := "{{inputs.parameters.publish-kafka}}" }}
-          - name: publish-snapshot
-          {{- $publishSnapshot := "{{inputs.parameters.publish-snapshot}}" }}
       # Limit to processing 1 table at a time to avoid lock failures in Jade.
       parallelism: 1
       dag:
@@ -96,15 +94,6 @@ spec:
                   value: {{ $releaseDate | quote }}
                 - name: ingest-summary
                   value: {{ $summary | quote }}
-
-          - name: publish-snapshot
-            dependencies: [process-tables]
-            when: {{ printf "%s == true" $publishSnapshot | quote }}
-            template: create-snapshot
-            arguments:
-              parameters:
-                - name: release-date
-                  value: {{ $releaseDate | quote }}
 
     ##
     ## Update the Jade state of a single table to match data staged in GCS.
@@ -481,100 +470,3 @@ spec:
         command: [python]
         source: |
         {{- include "argo.render-lines" (.Files.Lines "scripts/notify-clingen-kafka.py") | indent 10 }}
-
-    ##
-    ## Create a snapshot containing all live data in the ClinVar dataset.
-    ##
-    - name: create-snapshot
-      inputs:
-        parameters:
-          - name: release-date
-          {{- $releaseDate := "{{inputs.parameters.release-date}}" }}
-      dag:
-        tasks:
-          - name: get-snapshot-name
-            template: get-snapshot-name
-            arguments:
-              parameters:
-                - name: release-date
-                  value: {{ $releaseDate | quote }}
-          {{- $snapshotName := "{{tasks.get-snapshot-name.outputs.result}}" }}
-
-          - name: submit-job
-            dependencies: [get-snapshot-name]
-            template: submit-full-view-snapshot
-            arguments:
-              parameters:
-                - name: snapshot-name
-                  value: {{ $snapshotName | quote }}
-          {{ $jobId := "{{tasks.submit-job.outputs.result}}" }}
-
-          - name: poll-job
-            dependencies: [submit-job]
-            template: poll-ingest-job
-            arguments:
-              parameters:
-                - name: job-id
-                  value: {{ $jobId | quote }}
-                {{- with .Values.jade }}
-                - name: api-url
-                  value: {{ .url }}
-                - name: timeout
-                  value: {{ .pollTimeout | quote }}
-                - name: sa-secret
-                  value: {{ .accessKey.secretName }}
-                - name: sa-secret-key
-                  value: {{ .accessKey.secretKey }}
-                {{- end }}
-
-    ##
-    ## Transform a release-date into a TDR snapshot name.
-    ##
-    - name: get-snapshot-name
-      inputs:
-        parameters:
-          - name: release-date
-          {{- $releaseDate := "{{inputs.parameters.release-date}}" }}
-      script:
-        image: python:3-slim
-        command: [python]
-        source: |
-          release_date = '{{ $releaseDate }}'
-          print(f"clinvar_{release_date.replace('-', '_')}")
-
-    ##
-    ## Submit a job to the TDR which will create a snapshot of all live data in a dataset.
-    ##
-    - name: submit-full-view-snapshot
-      inputs:
-        parameters:
-          - name: snapshot-name
-          {{- $snapshotName := "{{inputs.parameters.snapshot-name}}" }}
-      volumes:
-        {{- with .Values.jade }}
-        - name: sa-secret-volume
-          secret:
-            secretName: {{ .accessKey.secretName }}
-      script:
-        image: us.gcr.io/broad-dsp-gcr-public/monster-auth-req-py:1.0.1
-        volumeMounts:
-          - name: sa-secret-volume
-            mountPath: /secret
-        env:
-          - name: API_URL
-            value: {{ .url }}
-          - name: DATASET_NAME
-            value: {{ .datasetName }}
-          - name: PROFILE_ID
-            value: {{ .profileId }}
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: {{ printf "/secret/%s" .accessKey.secretKey }}
-        {{- end }}
-          - name: SNAPSHOT_NAME
-            value: {{ $snapshotName | quote }}
-        command: [python]
-        source: |
-        {{- include "argo.render-lines" (.Files.Lines "scripts/request-full-view-snapshot.py") | indent 10 }}
-
-    ## Inject template used to poll TDR jobs.
-    {{- include "argo.poll-ingest-job" . | indent 4 }}

--- a/orchestration/templates/ingest-processed-archive.yaml
+++ b/orchestration/templates/ingest-processed-archive.yaml
@@ -540,7 +540,7 @@ spec:
         command: [python]
         source: |
           release_date = '{{ $releaseDate }}'
-          print(f'clinvar_{release_date.replace('-', '_')}')
+          print(f"clinvar_{release_date.replace('-', '_')}")
 
     ##
     ## Submit a job to the TDR which will create a snapshot of all live data in a dataset.

--- a/orchestration/templates/ingest-processed-archive.yaml
+++ b/orchestration/templates/ingest-processed-archive.yaml
@@ -21,12 +21,14 @@ spec:
           {{- $releaseDate := "{{inputs.parameters.release-date}}" }}
           - name: publish-kafka
           {{- $publishKafka := "{{inputs.parameters.publish-kafka}}" }}
+          - name: publish-snapshot
+          {{- $publishSnapshot := "{{inputs.parameters.publish-snapshot}}" }}
       # Limit to processing 1 table at a time to avoid lock failures in Jade.
       parallelism: 1
       dag:
         tasks:
           # Create a dataset to store intermediate outputs of ETL jobs.
-          {{- $datasetName := printf "%s_%s" .Values.bigquery.stagingData.datasetPrefix $gcsPrefix }}
+          {{- $datasetName := printf "%s_%s" .Values.staging.bigquery.datasetPrefix $gcsPrefix }}
           - name: create-dataset
             templateRef:
               name: {{ .Values.argoTemplates.createBQDataset.name }}
@@ -34,14 +36,14 @@ spec:
             arguments:
               parameters:
                 - name: dataset-name
-                  value: {{ $datasetName }}
-                {{- with .Values.bigquery.stagingData }}
+                  value: {{ $datasetName | quote }}
+                {{- with .Values.staging.bigquery }}
                 - name: bq-project
-                  value: '{{ .project }}'
+                  value: {{ .project }}
                 - name: dataset-description
-                  value: '{{ .description }}'
+                  value: {{ .description }}
                 - name: dataset-expiration
-                  value: '{{ .expiration }}'
+                  value: {{ .expiration }}
                 {{- end }}
 
           # Write the archive's release date into ClinGen's bucket.
@@ -50,9 +52,9 @@ spec:
             arguments:
               parameters:
                 - name: gcs-prefix
-                  value: '{{ $gcsPrefix }}'
+                  value: {{ $gcsPrefix | quote }}
                 - name: release-date
-                  value: '{{ $releaseDate }}'
+                  value: {{ $releaseDate | quote }}
 
           # Loop over all tables, syncing state in Jade to match data staged in GCS.
           - name: process-tables
@@ -77,23 +79,32 @@ spec:
             arguments:
               parameters:
                 - name: dataset-name
-                  value: '{{ $datasetName }}'
+                  value: {{ $datasetName | quote }}
                 - name: gcs-prefix
-                  value: '{{ $gcsPrefix }}'
+                  value: {{ $gcsPrefix | quote }}
                 - name: table-name
-                  value: '{{ "{{item}}" }}'
+                  value: {{ "{{item}}" | quote }}
             {{- $summary := "{{tasks.process-tables.outputs.parameters}}" }}
 
           - name: notify-clingen
             dependencies: [process-tables]
-            when: '{{ printf "%s == true" $publishKafka }}'
+            when: {{ printf "%s == true" $publishKafka | quote }}
             template: notify-clingen-kafka
             arguments:
               parameters:
                 - name: release-date
-                  value: '{{ $releaseDate }}'
+                  value: {{ $releaseDate | quote }}
                 - name: ingest-summary
-                  value: '{{ $summary }}'
+                  value: {{ $summary | quote }}
+
+          - name: publish-snapshot
+            dependencies: [process-tables]
+            when: {{ printf "%s == true" $publishSnapshot | quote }}
+            template: create-snapshot
+            arguments:
+              parameters:
+                - name: release-date
+                  value: {{ $releaseDate | quote }}
 
     ##
     ## Update the Jade state of a single table to match data staged in GCS.
@@ -122,23 +133,23 @@ spec:
             arguments:
               parameters:
                 - name: table-name
-                  value: '{{ $tableName }}'
+                  value: {{ $tableName | quote }}
                 - name: gcs-bucket
-                  value: '{{ .Values.gcs.bucketName }}'
+                  value: {{ .Values.staging.gcsBucket }}
                 - name: input-prefix
-                  value: '{{ printf "%s/processed/%s" $gcsPrefix $tableName }}'
+                  value: {{ printf "%s/processed/%s" $gcsPrefix $tableName | quote }}
                 - name: old-ids-output-prefix
-                  value: '{{ $oldIdsPrefix }}'
+                  value: {{ $oldIdsPrefix | quote }}
                 - name: new-rows-output-prefix
-                  value: '{{ $newRowsPrefix }}'
+                  value: {{ $newRowsPrefix | quote }}
                 - name: staging-bq-project
-                  value: '{{ .Values.bigquery.stagingData.project }}'
+                  value: {{ .Values.staging.bigquery.project }}
                 - name: staging-bq-dataset
-                  value: '{{ $datasetName }}'
+                  value: {{ $datasetName | quote }}
                 - name: jade-bq-project
-                  value: '{{ .Values.bigquery.jadeData.project }}'
+                  value: {{ .Values.jade.dataProject }}
                 - name: jade-bq-dataset
-                  value: '{{ .Values.bigquery.jadeData.dataset }}'
+                  value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
             {{- $joinTable := "{{tasks.diff-table.outputs.parameters.join-table-name}}" }}
             {{- $shouldAppend := "{{tasks.diff-table.outputs.parameters.rows-to-append-count}} > 0" }}
             {{- $shouldDelete := "{{tasks.diff-table.outputs.parameters.ids-to-delete-count}} > 0" }}
@@ -146,57 +157,57 @@ spec:
           # Soft-delete IDs of outdated rows.
           - name: soft-delete-table
             dependencies: [diff-table]
-            when: '{{ $shouldDelete }}'
+            when: {{ $shouldDelete | quote }}
             templateRef:
               name: {{ .Values.argoTemplates.softDeleteTable.name }}
               template: main
             arguments:
               parameters:
                 - name: table-name
-                  value: '{{ $tableName }}'
+                  value: {{ $tableName | quote }}
                 - name: gcs-prefix
-                  value: '{{ $oldIdsPrefix }}'
+                  value: {{ $oldIdsPrefix | quote }}
                 - name: gcs-bucket
-                  value: '{{ .Values.gcs.bucketName }}'
-                {{- with .Values.repo }}
+                  value: {{ .Values.staging.gcsBucket }}
+                {{- with .Values.jade }}
                 - name: url
-                  value: '{{ .url }}'
+                  value: {{ .url }}
                 - name: dataset-id
-                  value: '{{ .datasetId }}'
+                  value: {{ .datasetId }}
                 - name: timeout
-                  value: '{{ .pollTimeout }}'
+                  value: {{ .pollTimeout }}
                 - name: sa-secret
-                  value: '{{ .accessKey.secretName }}'
+                  value: {{ .accessKey.secretName }}
                 - name: sa-secret-key
-                  value: '{{ .accessKey.secretKey }}'
+                  value: {{ .accessKey.secretKey }}
                 {{- end }}
 
           # Append rows with new data.
           - name: ingest-table
             dependencies: [diff-table, soft-delete-table]
-            when: '{{ $shouldAppend }}'
+            when: {{ $shouldAppend | quote }}
             templateRef:
               name:  {{ .Values.argoTemplates.ingestTable.name }}
               template: main
             arguments:
               parameters:
                 - name: table-name
-                  value: '{{ $tableName }}'
+                  value: {{ $tableName | quote }}
                 - name: gcs-bucket
-                  value: '{{ .Values.gcs.bucketName }}'
+                  value: {{ .Values.staging.gcsBucket }}
                 - name: gcs-prefix
-                  value: '{{ $newRowsPrefix }}'
-                {{- with .Values.repo }}
+                  value: {{ $newRowsPrefix | quote }}
+                {{- with .Values.jade }}
                 - name: url
-                  value: '{{ .url }}'
+                  value: {{ .url }}
                 - name: dataset-id
-                  value: '{{ .datasetId }}'
+                  value: {{ .datasetId }}
                 - name: timeout
-                  value: '{{ .pollTimeout }}'
+                  value: {{ .pollTimeout }}
                 - name: sa-secret
-                  value: '{{ .accessKey.secretName }}'
+                  value: {{ .accessKey.secretName }}
                 - name: sa-secret-key
-                  value: '{{ .accessKey.secretKey }}'
+                  value: {{ .accessKey.secretKey }}
                 {{- end }}
 
           # Build the export prefixes for the table's ClinGen data.
@@ -208,9 +219,9 @@ spec:
             arguments:
               parameters:
                 - name: table-name
-                  value: '{{ $tableName }}'
+                  value: {{ $tableName | quote }}
                 - name: gcs-prefix
-                  value: '{{ $gcsPrefix }}'
+                  value: {{ $gcsPrefix | quote }}
             {{- $createdPath := "{{tasks.build-export-paths.outputs.parameters.created-path}}" }}
             {{- $updatedPath := "{{tasks.build-export-paths.outputs.parameters.updated-path}}" }}
             {{- $deletedPath := "{{tasks.build-export-paths.outputs.parameters.deleted-path}}" }}
@@ -222,11 +233,11 @@ spec:
             arguments:
               parameters:
                 - name: bq-dataset
-                  value: '{{ $datasetName }}'
+                  value: {{ $datasetName | quote }}
                 - name: join-table-name
-                  value: '{{ $joinTable }}'
+                  value: {{ $joinTable | quote }}
                 - name: table-name
-                  value: '{{ $tableName }}'
+                  value: {{ $tableName | quote }}
                 - name: query-type
                   value: new_rows
             {{- $newRowsTable := "{{tasks.generate-new-rows-table.outputs.result}}" }}
@@ -239,17 +250,17 @@ spec:
             arguments:
               parameters:
                 - name: bq-project
-                  value: '{{ .Values.bigquery.stagingData.project }}'
+                  value: {{ .Values.staging.bigquery.project }}
                 - name: bq-dataset
-                  value: '{{ $datasetName }}'
+                  value: {{ $datasetName | quote }}
                 - name: bq-table
-                  value: '{{ $newRowsTable }}'
+                  value: {{ $newRowsTable | quote }}
                 - name: output-format
                   value: NEWLINE_DELIMITED_JSON
                 - name: gcs-bucket
-                  value: '{{ .Values.gcs.resultBucketName }}'
+                  value: {{ .Values.clingen.gcsBucket }}
                 - name: gcs-prefix
-                  value: '{{ $createdPath }}'
+                  value: {{ $createdPath | quote }}
             {{- $createdCount := "{{tasks.export-new-rows-table.outputs.parameters.row-count}}" }}
 
           # Export updated rows to GCS for ClinGen
@@ -259,11 +270,11 @@ spec:
             arguments:
               parameters:
                 - name: bq-dataset
-                  value: '{{ $datasetName }}'
+                  value: {{ $datasetName | quote }}
                 - name: join-table-name
-                  value: '{{ $joinTable }}'
+                  value: {{ $joinTable | quote }}
                 - name: table-name
-                  value: '{{ $tableName }}'
+                  value: {{ $tableName | quote }}
                 - name: query-type
                   value: updates
             {{- $updatesTable := "{{tasks.generate-updated-rows-table.outputs.result}}" }}
@@ -276,17 +287,17 @@ spec:
             arguments:
               parameters:
                 - name: bq-project
-                  value: '{{ .Values.bigquery.stagingData.project }}'
+                  value: {{ .Values.staging.bigquery.project }}
                 - name: bq-dataset
-                  value: '{{ $datasetName }}'
+                  value: {{ $datasetName | quote }}
                 - name: bq-table
-                  value: '{{ $updatesTable }}'
+                  value: {{ $updatesTable | quote }}
                 - name: output-format
                   value: NEWLINE_DELIMITED_JSON
                 - name: gcs-bucket
-                  value: '{{ .Values.gcs.resultBucketName }}'
+                  value: {{ .Values.clingen.gcsBucket }}
                 - name: gcs-prefix
-                  value: '{{ $updatedPath }}'
+                  value: {{ $updatedPath | quote }}
             {{- $updatedCount := "{{tasks.export-updated-rows-table.outputs.parameters.row-count}}" }}
 
           # Export deleted row keys to GCS for ClinGen
@@ -296,11 +307,11 @@ spec:
             arguments:
               parameters:
                 - name: bq-dataset
-                  value: '{{ $datasetName }}'
+                  value: {{ $datasetName | quote }}
                 - name: join-table-name
-                  value: '{{ $joinTable }}'
+                  value: {{ $joinTable | quote }}
                 - name: table-name
-                  value: '{{ $tableName }}'
+                  value: {{ $tableName | quote }}
             {{- $deletionsTable := "{{tasks.generate-deleted-rows-table.outputs.result}}" }}
 
           - name: export-deleted-rows-table
@@ -311,39 +322,39 @@ spec:
             arguments:
               parameters:
                 - name: bq-project
-                  value: '{{ .Values.bigquery.stagingData.project }}'
+                  value: {{ .Values.staging.bigquery.project }}
                 - name: bq-dataset
-                  value: '{{ $datasetName }}'
+                  value: {{ $datasetName | quote }}
                 - name: bq-table
-                  value: '{{ $deletionsTable }}'
+                  value: {{ $deletionsTable | quote }}
                 - name: output-format
                   value: NEWLINE_DELIMITED_JSON
                 - name: gcs-bucket
-                  value: '{{ .Values.gcs.resultBucketName }}'
+                  value: {{ .Values.clingen.gcsBucket }}
                 - name: gcs-prefix
-                  value: '{{ $deletedPath }}'
+                  value: {{ $deletedPath | quote }}
             {{- $deletedCount := "{{tasks.export-deleted-rows-table.outputs.parameters.row-count}}" }}
 
       outputs:
         parameters:
           - name: created-prefix
             valueFrom:
-              parameter: '{{ $createdPath }}'
+              parameter: {{ $createdPath | quote }}
           - name: created-count
             valueFrom:
-              parameter: '{{ $createdCount }}'
+              parameter: {{ $createdCount | quote }}
           - name: updated-prefix
             valueFrom:
-              parameter: '{{ $updatedPath }}'
+              parameter: {{ $updatedPath | quote }}
           - name: updated-count
             valueFrom:
-              parameter: '{{ $updatedCount }}'
+              parameter: {{ $updatedCount | quote }}
           - name: deleted-prefix
             valueFrom:
-              parameter: '{{ $deletedPath }}'
+              parameter: {{ $deletedPath | quote }}
           - name: deleted-count
             valueFrom:
-              parameter: '{{ $deletedCount }}'
+              parameter: {{ $deletedCount | quote }}
 
     ##
     ## Plumbing task to get create/update/delete prefixes into a format
@@ -388,21 +399,20 @@ spec:
           - name: join-table-name
           - name: bq-dataset
           - name: query-type
-      {{- include "argo.retry" . | indent 6 }}
       script:
         image: {{ $schemaImage }}
         # layer of env variables to make the scripts more stand-alone and more compatible within editors
         env:
           - name: PROJECT
-            value: '{{ .Values.bigquery.stagingData.project }}'
+            value: {{ .Values.staging.bigquery.project }}
           - name: DATASET
-            value: '{{ "{{inputs.parameters.bq-dataset}}" }}'
+            value: {{ "{{inputs.parameters.bq-dataset}}" | quote }}
           - name: INPUT_TABLE
-            value: '{{ "{{inputs.parameters.join-table-name}}" }}'
+            value: {{ "{{inputs.parameters.join-table-name}}" | quote }}
           - name: TABLE
-            value: '{{ "{{inputs.parameters.table-name}}" }}'
+            value: {{ "{{inputs.parameters.table-name}}" | quote }}
           - name: QUERY_TYPE
-            value: '{{ "{{inputs.parameters.query-type}}" }}'
+            value: {{ "{{inputs.parameters.query-type}}" | quote }}
         command: [bash]
         source: |
         {{- include "argo.render-lines" (.Files.Lines "scripts/clingen-temp-table-full-rows.sh") | indent 10 }}
@@ -414,18 +424,17 @@ spec:
           - name: table-name
           - name: join-table-name
           - name: bq-dataset
-      {{- include "argo.retry" . | indent 6 }}
       script:
         image: {{ $schemaImage }}
         env:
           - name: PROJECT
-            value: '{{ .Values.bigquery.stagingData.project }}'
+            value: {{ .Values.staging.bigquery.project }}
           - name: DATASET
-            value: '{{ "{{inputs.parameters.bq-dataset}}" }}'
+            value: {{ "{{inputs.parameters.bq-dataset}}" | quote }}
           - name: INPUT_TABLE
-            value: '{{ "{{inputs.parameters.join-table-name}}" }}'
+            value: {{ "{{inputs.parameters.join-table-name}}" | quote }}
           - name: TABLE
-            value: '{{ "{{inputs.parameters.table-name}}" }}'
+            value: {{ "{{inputs.parameters.table-name}}" | quote }}
         command: [bash]
         source: |
         {{- include "argo.render-lines" (.Files.Lines "scripts/clingen-temp-table-pk-deletes.sh") | indent 10 }}
@@ -440,7 +449,7 @@ spec:
       script:
         image: google/cloud-sdk:slim
         command: [bash]
-        {{- $uploadPath := printf "gs://%s/%s/" .Values.gcs.resultBucketName $gcsPrefix }}
+        {{- $uploadPath := printf "gs://%s/%s/" .Values.clingen.gcsBucket $gcsPrefix }}
         source: |
           echo "{{ $releaseDate }}" > release_date.txt
           gsutil cp release_date.txt {{ $uploadPath }}
@@ -459,16 +468,113 @@ spec:
         image: us.gcr.io/broad-dsp-gcr-public/clingen-notifier:1.0.0
         env:
           - name: RELEASE_DATE
-            value: '{{ $releaseDate }}'
+            value: {{ $releaseDate | quote }}
           - name: GCS_BUCKET
-            value: '{{ .Values.gcs.resultBucketName }}'
+            value: {{ .Values.clingen.gcsBucket }}
           - name: INGEST_SUMMARY
-            value: '{{ $ingestSummary }}'
+            value: {{ $ingestSummary | quote }}
           - name: KAFKA_TOPIC
-            value: '{{ .Values.kafka.topic }}'
+            value: {{ .Values.clingen.kafka.topic }}
         envFrom:
           - secretRef:
-              name: '{{ .Values.kafka.secretName }}'
+              name: {{ .Values.clingen.kafka.secretName }}
         command: [python]
         source: |
         {{- include "argo.render-lines" (.Files.Lines "scripts/notify-clingen-kafka.py") | indent 10 }}
+
+    ##
+    ## Create a snapshot containing all live data in the ClinVar dataset.
+    ##
+    - name: create-snapshot
+      inputs:
+        parameters:
+          - name: release-date
+          {{- $releaseDate := "{{inputs.parameters.release-date}}" }}
+      dag:
+        tasks:
+          - name: get-snapshot-name
+            template: get-snapshot-name
+            arguments:
+              parameters:
+                - name: release-date
+                  value: {{ $releaseDate | quote }}
+          {{- $snapshotName := "{{tasks.get-snapshot-name.outputs.result}}" }}
+
+          - name: submit-job
+            dependencies: [get-snapshot-name]
+            template: submit-full-view-snapshot
+            arguments:
+              parameters:
+                - name: snapshot-name
+                  value: {{ $snapshotName | quote }}
+          {{ $jobId := "{{tasks.submit-job.outputs.result}}" }}
+
+          - name: poll-job
+            dependencies: [submit-job]
+            template: poll-ingest-job
+            arguments:
+              parameters:
+                - name: job-id
+                  value: {{ $jobId | quote }}
+                {{- with .Values.jade }}
+                - name: api-url
+                  value: {{ .url }}
+                - name: timeout
+                  value: {{ .pollTimeout | quote }}
+                - name: sa-secret
+                  value: {{ .accessKey.secretName }}
+                - name: sa-secret-key
+                  value: {{ .accessKey.secretKey }}
+                {{- end }}
+
+    ##
+    ## Transform a release-date into a TDR snapshot name.
+    ##
+    - name: get-snapshot-name
+      inputs:
+        parameters:
+          - name: release-date
+          {{- $releaseDate := "{{inputs.parameters.release-date}}" }}
+      script:
+        image: python:3-slim
+        command: [python]
+        source: |
+          release_date = '{{ $releaseDate }}'
+          print(f'clinvar_{release_date.replace('-', '_')}')
+
+    ##
+    ## Submit a job to the TDR which will create a snapshot of all live data in a dataset.
+    ##
+    - name: submit-full-view-snapshot
+      inputs:
+        parameters:
+          - name: snapshot-name
+          {{- $snapshotName := "{{inputs.parameters.snapshot-name}}" }}
+      volumes:
+        {{- with .Values.jade }}
+        - name: sa-secret-volume
+          secret:
+            secretName: {{ .accessKey.secretName }}
+      script:
+        image: us.gcr.io/broad-dsp-gcr-public/monster-auth-req-py:1.0.1
+        volumeMounts:
+          - name: sa-secret-volume
+            mountPath: /secret
+        env:
+          - name: API_URL
+            value: {{ .url }}
+          - name: DATASET_NAME
+            value: {{ .datasetName }}
+          - name: PROFILE_ID
+            value: {{ .profileId }}
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: {{ printf "/secret/%s" .accessKey.secretKey }}
+        {{- end }}
+          - name: SNAPSHOT_NAME
+            value: {{ $snapshotName | quote }}
+        command: [python]
+        source: |
+        {{- include "argo.render-lines" (.Files.Lines "scripts/request-full-view-snapshot.py") | indent 10 }}
+
+    ## Inject template used to poll TDR jobs.
+    {{- include "argo.poll-ingest-job" . | indent 4 }}

--- a/orchestration/templates/ingest-raw-archive.yaml
+++ b/orchestration/templates/ingest-raw-archive.yaml
@@ -28,19 +28,19 @@ spec:
             arguments:
               parameters:
                 - name: release-date
-                  value: '{{ $releaseDate }}'
-            {{- $shouldIngest := "{{tasks.check-for-existing-release.outputs.result}} == 0"}}
+                  value: {{ $releaseDate | quote }}
+            {{- $shouldIngest := "{{tasks.check-for-existing-release.outputs.result}} == 0" }}
 
           - name: ingest-release
             dependencies: [check-for-existing-release]
-            when: '{{ $shouldIngest }}'
+            when: {{ $shouldIngest | quote }}
             template: ingest-release
             arguments:
               parameters:
                 - name: release-date
-                  value: '{{ $releaseDate }}'
+                  value: {{ $releaseDate | quote }}
                 - name: gcs-prefix
-                  value: '{{ $gcsPrefix }}'
+                  value: {{ $gcsPrefix | quote }}
 
     ##
     ## Sub-dag to ingest a raw release into the Repo and register it in the release_history table.
@@ -65,18 +65,18 @@ spec:
             arguments:
               parameters:
                 - name: virtual-path
-                  value: '{{ $targetPath }}'
-                {{- with .Values.repo }}
+                  value: {{ $targetPath | quote }}
+                {{- with .Values.jade }}
                 - name: url
-                  value: '{{ .url }}'
+                  value: {{ .url }}
                 - name: dataset-id
-                  value: '{{ .datasetId }}'
+                  value: {{ .datasetId }}
                 - name: profile-id
-                  value: '{{ .profileId }}'
+                  value: {{ .profileId }}
                 - name: sa-secret
-                  value: '{{ .accessKey.secretName }}'
+                  value: {{ .accessKey.secretName }}
                 - name: sa-secret-key
-                  value: '{{ .accessKey.secretKey }}'
+                  value: {{ .accessKey.secretKey }}
                 {{- end }}
             {{- $existingFileId := "{{tasks.check-for-existing-file.outputs.result}}" }}
             {{- $shouldIngestFile := printf "%s == null" $existingFileId }}
@@ -84,61 +84,61 @@ spec:
           # If we've already ingested a file, use it to ingest the matching row.
           - name: ingest-release-history-existing-file
             dependencies: [check-for-existing-file]
-            when: '{{ printf "%s != null" $existingFileId }}'
+            when: {{ (printf "%s != null" $existingFileId) | quote }}
             template: ingest-release-history
             arguments:
               parameters:
                 - name: release-date
-                  value: '{{ $releaseDate }}'
+                  value: {{ $releaseDate | quote }}
                 - name: file-id
-                  value: '{{ $existingFileId }}'
+                  value: {{ $existingFileId | quote }}
                 - name: gcs-prefix
-                  value: '{{ $gcsPrefix }}'
+                  value: {{ $gcsPrefix | quote }}
 
           # If we haven't already ingested a file, start by loading the staged XML into Jade.
           - name: ingest-raw-xml
             dependencies: [check-for-existing-file]
-            when: '{{ $shouldIngestFile }}'
+            when: {{ $shouldIngestFile | quote }}
             templateRef:
               name: {{ .Values.argoTemplates.ingestFile.name }}
               template: main
             arguments:
               parameters:
-                {{- with .Values.repo }}
+                {{- with .Values.jade }}
                 - name: url
-                  value: '{{ .url }}'
+                  value: {{ .url }}
                 - name: dataset-id
-                  value: '{{ .datasetId }}'
+                  value: {{ .datasetId }}
                 - name: profile-id
-                  value: '{{ .profileId }}'
+                  value: {{ .profileId }}
                 - name: timeout
-                  value: '{{ .pollTimeout }}'
+                  value: {{ .pollTimeout }}
                 - name: sa-secret
-                  value: '{{ .accessKey.secretName }}'
+                  value: {{ .accessKey.secretName }}
                 - name: sa-secret-key
-                  value: '{{ .accessKey.secretKey }}'
+                  value: {{ .accessKey.secretKey }}
                 {{- end }}
                 - name: target-path
-                  value: '{{ $targetPath }}'
+                  value: {{ $targetPath | quote }}
                 - name: gcs-bucket
-                  value: '{{ .Values.gcs.bucketName }}'
+                  value: {{ .Values.staging.gcsBucket }}
                 - name: gcs-file-path
-                  value: '{{ $gcsPrefix }}/raw/{{ include "clinvar.raw-archive-name" . }}'
+                  value: {{ printf "%s/raw/%s" $gcsPrefix (include "clinvar.raw-archive-name" .) | quote }}
             {{- $newFileId := "{{tasks.ingest-raw-xml.outputs.parameters.file-id}}" }}
 
           # Ingest a row for the new file.
           - name: ingest-release-history-new-file
             dependencies: [ingest-raw-xml]
-            when: '{{ $shouldIngestFile }}'
+            when: {{ $shouldIngestFile | quote }}
             template: ingest-release-history
             arguments:
               parameters:
                 - name: release-date
-                  value: '{{ $releaseDate }}'
+                  value: {{ $releaseDate | quote }}
                 - name: file-id
-                  value: '{{ $newFileId }}'
+                  value: {{ $newFileId | quote }}
                 - name: gcs-prefix
-                  value: '{{ $gcsPrefix }}'
+                  value: {{ $gcsPrefix | quote }}
 
     ##
     ## Sub-dag to ingest a new row into the release_history table, once we've
@@ -161,11 +161,11 @@ spec:
             arguments:
               parameters:
                 - name: release-date
-                  value: '{{ $releaseDate }}'
+                  value: {{ $releaseDate | quote }}
                 - name: archive-id
-                  value: '{{ $fileId }}'
+                  value: {{ $fileId | quote }}
                 - name: gcs-prefix
-                  value: '{{ $gcsPrefix }}'
+                  value: {{ $gcsPrefix | quote }}
 
           # Ingest the staged release_history row.
           - name: ingest-release-history
@@ -178,20 +178,20 @@ spec:
                 - name: table-name
                   value: release_history
                 - name: gcs-bucket
-                  value: '{{ .Values.gcs.bucketName }}'
+                  value: {{ .Values.staging.gcsBucket }}
                 - name: gcs-prefix
-                  value: '{{ printf "%s/processed/release_history" $gcsPrefix }}'
-                {{- with .Values.repo }}
+                  value: {{ printf "%s/processed/release_history" $gcsPrefix | quote }}
+                {{- with .Values.jade }}
                 - name: url
-                  value: '{{ .url }}'
+                  value: {{ .url }}
                 - name: dataset-id
-                  value: '{{ .datasetId }}'
+                  value: {{ .datasetId }}
                 - name: timeout
-                  value: '{{ .pollTimeout }}'
+                  value: {{ .pollTimeout }}
                 - name: sa-secret
-                  value: '{{ .accessKey.secretName }}'
+                  value: {{ .accessKey.secretName }}
                 - name: sa-secret-key
-                  value: '{{ .accessKey.secretKey }}'
+                  value: {{ .accessKey.secretKey }}
                 {{- end }}
 
     ##
@@ -206,13 +206,13 @@ spec:
         image: google/cloud-sdk:slim
         env:
           - name: PROJECT
-            value: '{{ .Values.bigquery.stagingData.project }}'
+            value: {{ .Values.staging.bigquery.project }}
           - name: JADE_PROJECT
-            value: '{{ .Values.bigquery.jadeData.project }}'
+            value: {{ .Values.jade.dataProject }}
           - name: JADE_DATASET
-            value: '{{ .Values.bigquery.jadeData.dataset }}'
+            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
           - name: RELEASE_DATE
-            value: '{{ $releaseDate }}'
+            value: {{ $releaseDate | quote }}
         command: [bash]
         source: |
         {{- include "argo.render-lines" (.Files.Lines "scripts/check-for-release.sh") | indent 10 }}
@@ -232,7 +232,7 @@ spec:
       script:
         image: google/cloud-sdk:slim
         command: [bash]
-        {{- $uploadPath := printf "gs://%s/%s/processed/release_history/" .Values.gcs.bucketName $gcsPrefix }}
+        {{- $uploadPath := printf "gs://%s/%s/processed/release_history/" .Values.staging.gcsBucket $gcsPrefix }}
         source: |
             json='{"release_date":"{{ $releaseDate }}","archive_path":"{{ $archiveId }}"}'
             echo "$json" > release_history.json

--- a/orchestration/templates/process-clinvar-archive.yaml
+++ b/orchestration/templates/process-clinvar-archive.yaml
@@ -31,9 +31,9 @@ spec:
                 - name: name-prefix
                   value: ftp-download
                 - name: size
-                  value: '{{ .Values.volumes.downloadSize }}'
+                  value: {{ .Values.volumes.downloadSize | quote }}
                 - name: storage-class
-                  value: '{{ .Values.volumes.storageClass }}'
+                  value: {{ .Values.volumes.storageClass }}
             {{- $downloadPvc := "{{tasks.generate-download-volume.outputs.parameters.pvc-name}}" }}
 
           # Download the raw XML onto the new PVC.
@@ -47,15 +47,15 @@ spec:
                 - name: ftp-site
                   value: 'ftp.ncbi.nlm.nih.gov'
                 - name: ftp-path
-                  value: 'pub/clinvar/xml/clinvar_variation/{{ $archivePath }}'
+                  value: pub/clinvar/xml/clinvar_variation/{{ $archivePath }}
                 - name: local-path
                   value: {{ include "clinvar.raw-archive-name" . }}
                 - name: pvc-name
-                  value: '{{ $downloadPvc }}'
+                  value: {{ $downloadPvc | quote }}
                 - name: memory
-                  value: '512Mi'
+                  value: 512Mi
                 - name: cpu
-                  value: '1000m'
+                  value: 1000m
 
           # Upload the raw XML to GCS.
           - name: upload-raw-archive
@@ -66,17 +66,17 @@ spec:
             arguments:
               parameters:
                 - name: pvc-name
-                  value: '{{ $downloadPvc }}'
+                  value: {{ $downloadPvc | quote }}
                 - name: local-prefix
                   value: ''
                 - name: gcs-bucket
-                  value: '{{ .Values.gcs.bucketName }}'
+                  value: {{ .Values.staging.gcsBucket }}
                 - name: gcs-prefix
-                  value: '{{ $gcsPrefix }}/raw'
+                  value: {{ (printf "%s/raw" $gcsPrefix) | quote }}
                 - name: memory
-                  value: '1Gi'
+                  value: 1Gi
                 - name: cpu
-                  value: '1000m'
+                  value: 1000m
 
           # Generate a PVC to hold extracted JSON-list files.
           - name: generate-extraction-volume
@@ -90,9 +90,9 @@ spec:
                 - name: name-prefix
                   value: extracted-json
                 - name: size
-                  value: '{{ .Values.volumes.extractSize }}'
+                  value: {{ .Values.volumes.extractSize | quote }}
                 - name: storage-class
-                  value: '{{ .Values.volumes.storageClass }}'
+                  value: {{ .Values.volumes.storageClass }}
             {{- $extractionPvc := "{{tasks.generate-extraction-volume.outputs.parameters.pvc-name}}" }}
 
           # Extract raw XML to JSON-list.
@@ -104,11 +104,11 @@ spec:
             arguments:
               parameters:
                 - name: input-pvc-name
-                  value: '{{ $downloadPvc }}'
+                  value: {{ $downloadPvc | quote }}
                 - name: input-xml-path
                   value: {{ include "clinvar.raw-archive-name" . }}
                 - name: output-pvc-name
-                  value: '{{ $extractionPvc }}'
+                  value: {{ $extractionPvc | quote }}
                 - name: objects-per-part
                   value: '1024'
                 - name: gunzip
@@ -127,7 +127,7 @@ spec:
             arguments:
               parameters:
                 - name: pvc-name
-                  value: '{{ $downloadPvc }}'
+                  value: {{ $downloadPvc | quote }}
 
           # Upload extracted JSON-list data to GCS.
           - name: upload-extracted-archive
@@ -138,17 +138,17 @@ spec:
             arguments:
               parameters:
                 - name: pvc-name
-                  value: '{{ $extractionPvc }}'
+                  value: {{ $extractionPvc | quote }}
                 - name: local-prefix
                   value: VariationArchive
                 - name: gcs-bucket
-                  value:  '{{ .Values.gcs.bucketName }}'
+                  value:  {{ .Values.staging.gcsBucket }}
                 - name: gcs-prefix
-                  value: '{{ $gcsPrefix }}/raw/VariationArchive'
+                  value: {{ (printf "%s/raw/VariationArchive" $gcsPrefix) | quote }}
                 - name: memory
-                  value: '2Gi'
+                  value: 2Gi
                 - name: cpu
-                  value: '2000m'
+                  value: 2000m
 
           # Read the archive's release date from JSON.
           - name: extract-release-date
@@ -157,9 +157,9 @@ spec:
             arguments:
               parameters:
                 - name: pvc-name
-                  value: '{{ $extractionPvc }}'
+                  value: {{ $extractionPvc | quote }}
                 - name: file-path
-                  value: 'ClinVarVariationRelease/part-1.json'
+                  value: ClinVarVariationRelease/part-1.json
             {{- $releaseDate := "{{tasks.extract-release-date.outputs.result}}" }}
 
           # Clean up the extraction PVC
@@ -171,7 +171,7 @@ spec:
             arguments:
               parameters:
                 - name: pvc-name
-                  value: '{{ $extractionPvc }}'
+                  value: {{ $extractionPvc | quote }}
 
           # Use Dataflow to process the uploaded JSON-list
           - name: process-archive
@@ -180,7 +180,7 @@ spec:
             arguments:
               parameters:
                 - name: gcs-prefix
-                  value: '{{ $gcsPrefix }}'
+                  value: {{ $gcsPrefix | quote }}
 
       # Output the extracted release date so it can be used in following steps when
       # this workflow is launched by the over-arching orchestration pipeline.
@@ -188,7 +188,7 @@ spec:
         parameters:
           - name: release-date
             valueFrom:
-              parameter: '{{ $releaseDate }}'
+              parameter: {{ $releaseDate | quote }}
 
     ##
     ## Shim template used to extract the release date from
@@ -198,11 +198,13 @@ spec:
       inputs:
         parameters:
           - name: pvc-name
+          {{- $pvcName := "{{inputs.parameters.pvc-name}}" }}
           - name: file-path
+          {{- $filePath := "{{inputs.parameters.file-path}}" }}
       volumes:
         - name: state
           persistentVolumeClaim:
-            claimName: '{{ "{{inputs.parameters.pvc-name}}" }}'
+            claimName: {{ $pvcName | quote }}
             readOnly: true
       script:
         image: python:3-slim
@@ -213,7 +215,7 @@ spec:
             readOnly: true
         source: |
           import json
-          with open('/state/{{ "{{inputs.parameters.file-path}}" }}') as f:
+          with open('/state/{{ $filePath }}') as f:
             json_data = json.load(f)
           print(json_data["ClinVarVariationRelease"]["@ReleaseDate"])
 
@@ -232,7 +234,7 @@ spec:
         command: []
         args:
           - --runner=dataflow
-          {{- $bucket := .Values.gcs.bucketName }}
+          {{- $bucket := .Values.staging.gcsBucket }}
           - --inputPrefix=gs://{{ $bucket }}/{{ $prefix }}/raw
           - --outputPrefix=gs://{{ $bucket }}/{{ $prefix }}/processed
           {{- with .Values.dataflow }}

--- a/orchestration/templates/snapshot-dataset.yaml
+++ b/orchestration/templates/snapshot-dataset.yaml
@@ -68,7 +68,7 @@ spec:
         source: |
           release_date = '{{ $releaseDate }}'
           snapshot_name = f"clinvar_{release_date.replace('-', '_')}"
-          snapshot_description = f'Mirror of NCBI's ClinVar archive as of {release_date}'
+          snapshot_description = f"Mirror of NCBI's ClinVar archive as of {release_date}"
 
           with open('/name.txt', 'w') as namefile:
             namefile.write(snapshot_name)

--- a/orchestration/templates/snapshot-dataset.yaml
+++ b/orchestration/templates/snapshot-dataset.yaml
@@ -32,6 +32,8 @@ spec:
               parameters:
                 - name: snapshot-name
                   value: {{ $snapshotName | quote }}
+                - name: snapshot-description
+                  value: {{ $snapshotDescription | quote }}
           {{ $jobId := "{{tasks.submit-job.outputs.result}}" }}
 
           - name: poll-job

--- a/orchestration/templates/snapshot-dataset.yaml
+++ b/orchestration/templates/snapshot-dataset.yaml
@@ -1,0 +1,104 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: snapshot-dataset
+spec:
+  entrypoint: main
+  serviceAccountName: {{ .Values.serviceAccount.k8sName }}
+  templates:
+    ##
+    ## Entrypoint for freezing the current state of the ClinVar dataset as a snapshot.
+    ##
+    - name: main
+      inputs:
+        parameters:
+          - name: release-date
+          {{- $releaseDate := "{{inputs.parameters.release-date}}" }}
+      dag:
+        tasks:
+          - name: get-snapshot-name
+            template: get-snapshot-name
+            arguments:
+              parameters:
+                - name: release-date
+                  value: {{ $releaseDate | quote }}
+          {{- $snapshotName := "{{tasks.get-snapshot-name.outputs.result}}" }}
+
+          - name: submit-job
+            dependencies: [get-snapshot-name]
+            template: submit-full-view-snapshot
+            arguments:
+              parameters:
+                - name: snapshot-name
+                  value: {{ $snapshotName | quote }}
+          {{ $jobId := "{{tasks.submit-job.outputs.result}}" }}
+
+          - name: poll-job
+            dependencies: [submit-job]
+            template: poll-ingest-job
+            arguments:
+              parameters:
+                - name: job-id
+                  value: {{ $jobId | quote }}
+                {{- with .Values.jade }}
+                - name: api-url
+                  value: {{ .url }}
+                - name: timeout
+                  value: {{ .pollTimeout | quote }}
+                - name: sa-secret
+                  value: {{ .accessKey.secretName }}
+                - name: sa-secret-key
+                  value: {{ .accessKey.secretKey }}
+                {{- end }}
+
+    ##
+    ## Transform a release-date into a TDR snapshot name.
+    ##
+    - name: get-snapshot-name
+      inputs:
+        parameters:
+          - name: release-date
+          {{- $releaseDate := "{{inputs.parameters.release-date}}" }}
+      script:
+        image: python:3-slim
+        command: [python]
+        source: |
+          release_date = '{{ $releaseDate }}'
+          print(f"clinvar_{release_date.replace('-', '_')}")
+
+    ##
+    ## Submit a job to the TDR which will create a snapshot of all live data in a dataset.
+    ##
+    - name: submit-full-view-snapshot
+      inputs:
+        parameters:
+          - name: snapshot-name
+          {{- $snapshotName := "{{inputs.parameters.snapshot-name}}" }}
+      volumes:
+        {{- with .Values.jade }}
+        - name: sa-secret-volume
+          secret:
+            secretName: {{ .accessKey.secretName }}
+      script:
+        image: us.gcr.io/broad-dsp-gcr-public/monster-auth-req-py:1.0.1
+        volumeMounts:
+          - name: sa-secret-volume
+            mountPath: /secret
+        env:
+          - name: API_URL
+            value: {{ .url }}
+          - name: DATASET_NAME
+            value: {{ .datasetName }}
+          - name: PROFILE_ID
+            value: {{ .profileId }}
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: {{ printf "/secret/%s" .accessKey.secretKey }}
+        {{- end }}
+          - name: SNAPSHOT_NAME
+            value: {{ $snapshotName | quote }}
+        command: [python]
+        source: |
+        {{- include "argo.render-lines" (.Files.Lines "scripts/request-full-view-snapshot.py") | indent 10 }}
+
+    ## Inject template used to poll TDR jobs.
+    {{- include "argo.poll-ingest-job" . | indent 4 }}

--- a/orchestration/templates/snapshot-dataset.yaml
+++ b/orchestration/templates/snapshot-dataset.yaml
@@ -16,16 +16,17 @@ spec:
           {{- $releaseDate := "{{inputs.parameters.release-date}}" }}
       dag:
         tasks:
-          - name: get-snapshot-name
+          - name: get-snapshot-info
             template: get-snapshot-name
             arguments:
               parameters:
                 - name: release-date
                   value: {{ $releaseDate | quote }}
-          {{- $snapshotName := "{{tasks.get-snapshot-name.outputs.result}}" }}
+          {{- $snapshotName := "{{tasks.get-snapshot-info.outputs.parameters.name}}" }}
+          {{- $snapshotDescription := "{{tasks.get-snapshot-info.outputs.parameters.description}}" }}
 
           - name: submit-job
-            dependencies: [get-snapshot-name]
+            dependencies: [get-snapshot-info]
             template: submit-full-view-snapshot
             arguments:
               parameters:
@@ -54,7 +55,7 @@ spec:
     ##
     ## Transform a release-date into a TDR snapshot name.
     ##
-    - name: get-snapshot-name
+    - name: get-snapshot-info
       inputs:
         parameters:
           - name: release-date
@@ -64,7 +65,21 @@ spec:
         command: [python]
         source: |
           release_date = '{{ $releaseDate }}'
-          print(f"clinvar_{release_date.replace('-', '_')}")
+          snapshot_name = f"clinvar_{release_date.replace('-', '_')}"
+          snapshot_description = f'Mirror of NCBI's ClinVar archive as of {release_date}'
+
+          with open('/name.txt', 'w') as namefile:
+            namefile.write(snapshot_name)
+          with open('/description.txt', 'w') as descriptionfile:
+            descriptionfile.write(snapshot_description)
+      outputs:
+        parameters:
+          - name: name
+            valueFrom:
+              path: /name.txt
+          - name: description
+            valueFrom:
+              path: /description.txt
 
     ##
     ## Submit a job to the TDR which will create a snapshot of all live data in a dataset.
@@ -74,6 +89,8 @@ spec:
         parameters:
           - name: snapshot-name
           {{- $snapshotName := "{{inputs.parameters.snapshot-name}}" }}
+          - name: snapshot-description
+          {{- $snapshotDescription := "{{inputs.parameters.snapshot-description}}" }}
       volumes:
         {{- with .Values.jade }}
         - name: sa-secret-volume
@@ -96,6 +113,8 @@ spec:
         {{- end }}
           - name: SNAPSHOT_NAME
             value: {{ $snapshotName | quote }}
+          - name: SNAPSHOT_DESCRIPTION
+            value: {{ $snapshotDescription | quote }}
         command: [python]
         source: |
         {{- include "argo.render-lines" (.Files.Lines "scripts/request-full-view-snapshot.py") | indent 10 }}

--- a/orchestration/templates/snapshot-dataset.yaml
+++ b/orchestration/templates/snapshot-dataset.yaml
@@ -17,7 +17,7 @@ spec:
       dag:
         tasks:
           - name: get-snapshot-info
-            template: get-snapshot-name
+            template: get-snapshot-info
             arguments:
               parameters:
                 - name: release-date

--- a/orchestration/values.schema.json
+++ b/orchestration/values.schema.json
@@ -2,13 +2,42 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "gcs": {
+    "staging": {
       "type": "object",
       "properties": {
-        "bucketName": { "type": "string" },
-        "resultBucketName": {"type":  "string"}
+        "gcsBucket": { "type": "string" },
+        "bigquery": {
+          "type": "object",
+          "properties": {
+            "project": { "type": "string" },
+            "datasetPrefix": { "type": "string" },
+            "description": { "type": "string" },
+            "expiration": { "type": "string" }
+          },
+          "required": ["datasetPrefix", "description", "expiration"]
+        }
       },
-      "required": ["bucketName", "resultBucketName"]
+      "required": ["gcsBucket", "bigquery"]
+    },
+    "jade": {
+      "type": "object",
+      "properties": {
+        "url": { "type": "string" },
+        "datasetId": { "type": "string" },
+        "datasetName": { "type": "string" },
+        "profileId": { "type": "string" },
+        "pollTimeout": { "type": "integer" },
+        "dataProject": { "type": "string" },
+        "accessKey": {
+          "type": "object",
+          "properties": {
+            "secretName": { "type": "string" },
+            "secretKey": { "type": "string" }
+          },
+          "required": ["secretName", "secretKey"]
+        }
+      },
+      "required": ["url", "datasetId", "datasetName", "profileId", "pollTimeout", "dataProject", "accessKey"]
     },
     "serviceAccount": {
       "type": "object",
@@ -64,48 +93,6 @@
       "required": ["project", "region", "tmpBucketName",  "subnetName", "workerAccount",
                    "workerMachineType", "autoscaling", "useFlexRS"]
     },
-    "bigquery": {
-      "type": "object",
-      "properties": {
-        "stagingData": {
-          "type": "object",
-          "properties": {
-            "project": { "type": "string" },
-            "datasetPrefix": {"type": "string"},
-            "description": {"type": "string"},
-            "expiration": {"type": "string"}
-          },
-          "required": ["project", "datasetPrefix", "description", "expiration"]
-        },
-        "jadeData": {
-          "type": "object",
-          "properties": {
-            "project": { "type": "string" },
-            "dataset": { "type": "string" }
-          },
-          "required": ["project", "dataset"]
-        }
-      },
-      "required": ["stagingData", "jadeData"]
-    },
-    "repo" : {
-      "type": "object",
-      "properties": {
-        "url": {"type":  "string"},
-        "datasetId": {"type": "string"},
-        "profileId": {"type": "string"},
-        "pollTimeout": {"type":  "integer"},
-        "accessKey": {
-          "type": "object",
-          "properties": {
-            "secretName": {"type": "string"},
-            "secretKey": {"type": "string"}
-          },
-          "required": ["secretName", "secretKey"]
-        }
-      },
-      "required": ["url", "datasetId", "profileId", "pollTimeout", "accessKey"]
-    },
     "notification": {
       "type": "object",
       "properties": {
@@ -121,14 +108,21 @@
       },
       "required": ["onlyOnFailure", "slackUrl"]
     },
-    "kafka": {
+    "clingen": {
       "type": "object",
       "properties": {
-        "topic": { "type": "string" },
-        "secretName": { "type": "string" }
+        "gcsBucket": { "type": "string" },
+        "kafka": {
+          "type": "object",
+          "properties": {
+            "topic": { "type": "string" },
+            "secretName": { "type": "string" }
+          },
+          "required": ["topic", "secretName"]
+        }
       },
-      "required": ["topic", "secretName"]
+      "required": ["gcsBucket", "kafka"]
     }
   },
-  "required": ["gcs", "serviceAccount", "volumes", "cron", "dataflow", "repo", "notification", "kafka"]
+  "required": ["staging", "jade", "serviceAccount", "volumes", "cron", "dataflow", "notification", "clingen"]
 }

--- a/orchestration/values.yaml
+++ b/orchestration/values.yaml
@@ -14,7 +14,7 @@ dataflow:
     minWorkers: 4
     maxWorkers: 8
   useFlexRS: false
-repo:
+jade:
   # 24 hours -> 86400 seconds
   pollTimeout: 86400
 xmlToJsonList:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-val sbtPluginsVersion = "1.0.0"
+val sbtPluginsVersion = "1.1.0"
 
 val patternBase =
   "org/broadinstitute/monster/[module](_[scalaVersion])(_[sbtVersion])/[revision]"


### PR DESCRIPTION
I rearranged the values file as part of this to group things in a different way. The main motivation of that refactor was the need to have the user-defined dataset name as an argument (different from the existing arg for BQ dataset name). The BQ dataset name is derivable from the user-defined name, but our existing value name wasn't a good fit.

Here's an example of a successful run of the new WorkflowTemplate: https://argo.monster-dev.broadinstitute.org/archived-workflows/clinvar/14ae5bba-2ad8-4593-bc02-dc0f004e135e

Here's an example of full ingest run: https://argo.monster-dev.broadinstitute.org/workflows/clinvar/ingest-clinvar-archive-9mm27. I think we're hitting a bug in Jade's cleanup of old snapshots, because I deleted the 1st snapshot but the job is still failing from a duplicate name error.