### PR TITLE
DSPDC-1156 DSPDC-1149 Add processing_history table, release_date links.

### DIFF
--- a/schema/src/main/jade-assets/clinvar_release.asset.json
+++ b/schema/src/main/jade-assets/clinvar_release.asset.json
@@ -1,0 +1,93 @@
+{
+  "name": "clinvar_release",
+  "rootTable": "xml_archive",
+  "rootColumn": "release_date",
+  "tables": [
+    {
+      "name": "clinical_assertion",
+      "columns": []
+    },
+    {
+      "name": "clinical_assertion_observation",
+      "columns": []
+    },
+    {
+      "name": "clinical_assertion_trait",
+      "columns": []
+    },
+    {
+      "name": "clinical_assertion_trait_set",
+      "columns": []
+    },
+    {
+      "name": "clinical_assertion_variation",
+      "columns": []
+    },
+    {
+      "name": "gene",
+      "columns": []
+    },
+    {
+      "name": "gene_association",
+      "columns": []
+    },
+    {
+      "name": "processing_history",
+      "columns": []
+    },
+    {
+      "name": "rcv_accession",
+      "columns": []
+    },
+    {
+      "name": "submission",
+      "columns": []
+    },
+    {
+      "name": "submitter",
+      "columns": []
+    },
+    {
+      "name": "trait",
+      "columns": []
+    },
+    {
+      "name": "trait_mapping",
+      "columns": []
+    },
+    {
+      "name": "trait_set",
+      "columns": []
+    },
+    {
+      "name": "variation",
+      "columns": []
+    },
+    {
+      "name": "variation_archive",
+      "columns": []
+    },
+    {
+      "name": "xml_archive",
+      "columns": []
+    }
+  ],
+  "follow": [
+    "from_clinical_assertion.release_date_to_xml_archive.release_date",
+    "from_clinical_assertion_observation.release_date_to_xml_archive.release_date",
+    "from_clinical_assertion_trait.release_date_to_xml_archive.release_date",
+    "from_clinical_assertion_trait_set.release_date_to_xml_archive.release_date",
+    "from_clinical_assertion_variation.release_date_to_xml_archive.release_date",
+    "from_gene.release_date_to_xml_archive.release_date",
+    "from_gene_association.release_date_to_xml_archive.release_date",
+    "from_processing_history.release_date_to_xml_archive.release_date",
+    "from_rcv_accession.release_date_to_xml_archive.release_date",
+    "from_submission.release_date_to_xml_archive.release_date",
+    "from_submitter.release_date_to_xml_archive.release_date",
+    "from_trait.release_date_to_xml_archive.release_date",
+    "from_trait_mapping.release_date_to_xml_archive.release_date",
+    "from_trait_set.release_date_to_xml_archive.release_date",
+    "from_variation.release_date_to_xml_archive.release_date",
+    "from_variation_archive.release_date_to_xml_archive.release_date"
+  ]
+}

--- a/schema/src/main/jade-tables/clinical_assertion.table.json
+++ b/schema/src/main/jade-tables/clinical_assertion.table.json
@@ -9,7 +9,13 @@
     {
       "name": "release_date",
       "datatype": "date",
-      "type": "primary_key"
+      "type": "primary_key",
+      "links": [
+        {
+          "table_name": "xml_archive",
+          "column_name": "release_date"
+        }
+      ]
     },
     {
       "name": "version",

--- a/schema/src/main/jade-tables/clinical_assertion_trait.table.json
+++ b/schema/src/main/jade-tables/clinical_assertion_trait.table.json
@@ -9,7 +9,13 @@
     {
       "name": "release_date",
       "datatype": "date",
-      "type": "primary_key"
+      "type": "primary_key",
+      "links": [
+        {
+          "table_name": "xml_archive",
+          "column_name": "release_date"
+        }
+      ]
     },
     {
       "name": "trait_id",

--- a/schema/src/main/jade-tables/clinical_assertion_trait_set.table.json
+++ b/schema/src/main/jade-tables/clinical_assertion_trait_set.table.json
@@ -9,7 +9,13 @@
     {
       "name": "release_date",
       "datatype": "date",
-      "type": "primary_key"
+      "type": "primary_key",
+      "links": [
+        {
+          "table_name": "xml_archive",
+          "column_name": "release_date"
+        }
+      ]
     },
     {
       "name": "clinical_assertion_trait_ids",

--- a/schema/src/main/jade-tables/clinical_assertion_variation.table.json
+++ b/schema/src/main/jade-tables/clinical_assertion_variation.table.json
@@ -9,7 +9,13 @@
     {
       "name": "release_date",
       "datatype": "date",
-      "type": "primary_key"
+      "type": "primary_key",
+      "links": [
+        {
+          "table_name": "xml_archive",
+          "column_name": "release_date"
+        }
+      ]
     },
     {
       "name": "clinical_assertion_id",

--- a/schema/src/main/jade-tables/gene.table.json
+++ b/schema/src/main/jade-tables/gene.table.json
@@ -9,7 +9,13 @@
     {
       "name": "release_date",
       "datatype": "date",
-      "type": "primary_key"
+      "type": "primary_key",
+      "links": [
+        {
+          "table_name": "xml_archive",
+          "column_name": "release_date"
+        }
+      ]
     },
     {
       "name": "symbol",

--- a/schema/src/main/jade-tables/gene_association.table.json
+++ b/schema/src/main/jade-tables/gene_association.table.json
@@ -26,7 +26,13 @@
     {
       "name": "release_date",
       "datatype": "date",
-      "type": "primary_key"
+      "type": "primary_key",
+      "links": [
+        {
+          "table_name": "xml_archive",
+          "column_name": "release_date"
+        }
+      ]
     },
     {
       "name": "relationship_type",

--- a/schema/src/main/jade-tables/processing_history.table.json
+++ b/schema/src/main/jade-tables/processing_history.table.json
@@ -1,11 +1,6 @@
 {
-  "name": "clinical_assertion_observation",
+  "name": "processing_history",
   "columns": [
-    {
-      "name": "id",
-      "datatype": "string",
-      "type": "primary_key"
-    },
     {
       "name": "release_date",
       "datatype": "date",
@@ -18,17 +13,11 @@
       ]
     },
     {
-      "name": "clinical_assertion_trait_set_id",
-      "datatype": "string",
-      "links": [
-        {
-          "table_name": "clinical_assertion_trait_set",
-          "column_name": "id"
-        }
-      ]
+      "name": "processing_date",
+      "datatype": "date"
     },
     {
-      "name": "content",
+      "name": "pipeline_version",
       "datatype": "string"
     }
   ],

--- a/schema/src/main/jade-tables/rcv_accession.table.json
+++ b/schema/src/main/jade-tables/rcv_accession.table.json
@@ -9,7 +9,13 @@
     {
       "name": "release_date",
       "datatype": "date",
-      "type": "primary_key"
+      "type": "primary_key",
+      "links": [
+        {
+          "table_name": "xml_archive",
+          "column_name": "release_date"
+        }
+      ]
     },
     {
       "name": "version",

--- a/schema/src/main/jade-tables/submission.table.json
+++ b/schema/src/main/jade-tables/submission.table.json
@@ -9,7 +9,13 @@
     {
       "name": "release_date",
       "datatype": "date",
-      "type": "primary_key"
+      "type": "primary_key",
+      "links": [
+        {
+          "table_name": "xml_archive",
+          "column_name": "release_date"
+        }
+      ]
     },
     {
       "name": "submitter_id",

--- a/schema/src/main/jade-tables/submitter.table.json
+++ b/schema/src/main/jade-tables/submitter.table.json
@@ -9,7 +9,13 @@
     {
       "name": "release_date",
       "datatype": "date",
-      "type": "primary_key"
+      "type": "primary_key",
+      "links": [
+        {
+          "table_name": "xml_archive",
+          "column_name": "release_date"
+        }
+      ]
     },
     {
       "name": "org_category",

--- a/schema/src/main/jade-tables/trait.table.json
+++ b/schema/src/main/jade-tables/trait.table.json
@@ -9,7 +9,13 @@
     {
       "name": "release_date",
       "datatype": "date",
-      "type": "primary_key"
+      "type": "primary_key",
+      "links": [
+        {
+          "table_name": "xml_archive",
+          "column_name": "release_date"
+        }
+      ]
     },
     {
       "name": "medgen_id",

--- a/schema/src/main/jade-tables/trait_mapping.table.json
+++ b/schema/src/main/jade-tables/trait_mapping.table.json
@@ -35,7 +35,13 @@
     {
       "name": "release_date",
       "datatype": "date",
-      "type": "primary_key"
+      "type": "primary_key",
+      "links": [
+        {
+          "table_name": "xml_archive",
+          "column_name": "release_date"
+        }
+      ]
     },
     {
       "name": "medgen_id",

--- a/schema/src/main/jade-tables/trait_set.table.json
+++ b/schema/src/main/jade-tables/trait_set.table.json
@@ -9,7 +9,13 @@
     {
       "name": "release_date",
       "datatype": "date",
-      "type": "primary_key"
+      "type": "primary_key",
+      "links": [
+        {
+          "table_name": "xml_archive",
+          "column_name": "release_date"
+        }
+      ]
     },
     {
       "name": "trait_ids",

--- a/schema/src/main/jade-tables/variation.table.json
+++ b/schema/src/main/jade-tables/variation.table.json
@@ -9,7 +9,13 @@
     {
       "name": "release_date",
       "datatype": "date",
-      "type": "primary_key"
+      "type": "primary_key",
+      "links": [
+        {
+          "table_name": "xml_archive",
+          "column_name": "release_date"
+        }
+      ]
     },
     {
       "name": "subclass_type",

--- a/schema/src/main/jade-tables/variation_archive.table.json
+++ b/schema/src/main/jade-tables/variation_archive.table.json
@@ -9,7 +9,13 @@
     {
       "name": "release_date",
       "datatype": "date",
-      "type": "primary_key"
+      "type": "primary_key",
+      "links": [
+        {
+          "table_name": "xml_archive",
+          "column_name": "release_date"
+        }
+      ]
     },
     {
       "name": "version",


### PR DESCRIPTION
I wrote up ideas for how to use the new processing_history table in the doc: https://docs.google.com/document/d/1rpbyWCAaJCWC4CfbGWOq5VwZp1eoYUqRh-szxJ4Sw5w/edit#heading=h.r2seu6gorax6

The checked-in asset is required for cutting snapshots of single ClinVar releases (by date). We don't have any tooling to generate assets yet, so we'll need to inject it manually for now.