### PR TITLE
DSPDC-1130 Add codecov config.

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 75%
+        threshold: 5%
+


### PR DESCRIPTION
75% is better than most of our repos, but still feels attainable. Allowing a 5% drop in PRs feels realistic.