### PR TITLE
ra DSPDC 1311 diff bug

### DIFF
--- a/docker/diff/build.sh
+++ b/docker/diff/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-declare -r VERSION=1.0.8
+declare -r VERSION=1.0.9
 
 docker build -t us.gcr.io/broad-dsp-gcr-public/monster-bq-diff:${VERSION} .
 docker push us.gcr.io/broad-dsp-gcr-public/monster-bq-diff:${VERSION}

--- a/orchestration/templates/date-absent.yaml
+++ b/orchestration/templates/date-absent.yaml
@@ -60,7 +60,7 @@ spec:
           secret:
             secretName: {{ .Values.jade.accessKey.secretName }}
       script:
-        image: us.gcr.io/broad-dsp-gcr-public/monster-bq-diff:1.0.8
+        image: us.gcr.io/broad-dsp-gcr-public/monster-bq-diff:1.0.9
         volumeMounts:
           - name: sa-secret-volume
             mountPath: /secret
@@ -97,7 +97,7 @@ spec:
           secret:
             secretName: {{ .Values.jade.accessKey.secretName }}
       script:
-        image: us.gcr.io/broad-dsp-gcr-public/monster-bq-diff:1.0.8
+        image: us.gcr.io/broad-dsp-gcr-public/monster-bq-diff:1.0.9
         volumeMounts:
           - name: sa-secret-volume
             mountPath: /secret

--- a/orchestration/templates/date-present.yaml
+++ b/orchestration/templates/date-present.yaml
@@ -144,7 +144,7 @@ spec:
           secret:
             secretName: {{ .Values.jade.accessKey.secretName }}
       script:
-        image: us.gcr.io/broad-dsp-gcr-public/monster-bq-diff:1.0.8
+        image: us.gcr.io/broad-dsp-gcr-public/monster-bq-diff:1.0.9
         volumeMounts:
           - name: sa-secret-volume
             mountPath: /secret
@@ -187,7 +187,7 @@ spec:
           secret:
             secretName: {{ .Values.jade.accessKey.secretName }}
       script:
-        image: us.gcr.io/broad-dsp-gcr-public/monster-bq-diff:1.0.8
+        image: us.gcr.io/broad-dsp-gcr-public/monster-bq-diff:1.0.9
         volumeMounts:
           - name: sa-secret-volume
             mountPath: /secret
@@ -230,7 +230,7 @@ spec:
           secret:
             secretName: {{ .Values.jade.accessKey.secretName }}
       script:
-        image: us.gcr.io/broad-dsp-gcr-public/monster-bq-diff:1.0.8
+        image: us.gcr.io/broad-dsp-gcr-public/monster-bq-diff:1.0.9
         volumeMounts:
           - name: sa-secret-volume
             mountPath: /secret
@@ -273,7 +273,7 @@ spec:
           secret:
             secretName: {{ .Values.jade.accessKey.secretName }}
       script:
-        image: us.gcr.io/broad-dsp-gcr-public/monster-bq-diff:1.0.8
+        image: us.gcr.io/broad-dsp-gcr-public/monster-bq-diff:1.0.9
         volumeMounts:
           - name: sa-secret-volume
             mountPath: /secret


### PR DESCRIPTION
Update diff to insert pks for tables without `id` column, use updated image in workflow.

Tested the diffing on tables that had diffing generated correctly, those are still being generated and returning the same stuff as before. Now also works for gene_association and trait_mapping tables.