### PR TITLE
Add load tag to bulk ingest call

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -1,7 +1,4 @@
 coverage:
   status:
-    project:
-      default:
-        target: 75%
-        threshold: 5%
-
+    project: off
+    patch: off

--- a/.github/workflows/build-and-publish-master.yaml
+++ b/.github/workflows/build-and-publish-master.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Fetch tag history
         run: git fetch --tags
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: graalvm@20.0.0
       - name: Check formatting

--- a/.github/workflows/build-and-publish-release.yaml
+++ b/.github/workflows/build-and-publish-release.yaml
@@ -15,7 +15,7 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: graalvm@20.0.0
       - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master

--- a/.github/workflows/validate-pull-request.yaml
+++ b/.github/workflows/validate-pull-request.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: graalvm@20.0.0
       - name: Check formatting

--- a/orchestration/Chart.yaml
+++ b/orchestration/Chart.yaml
@@ -10,6 +10,6 @@ dependencies:
     repository: https://broadinstitute.github.io/monster-xml-to-json-list
     alias: xmlToJsonList
   - name: argo-templates
-    version: 1.2.2
+    version: 1.2.3
     repository: https://broadinstitute.github.io/monster-helm
     alias: argoTemplates

--- a/orchestration/Chart.yaml
+++ b/orchestration/Chart.yaml
@@ -10,6 +10,6 @@ dependencies:
     repository: https://broadinstitute.github.io/monster-xml-to-json-list
     alias: xmlToJsonList
   - name: argo-templates
-    version: 1.2.0
+    version: 1.2.2
     repository: https://broadinstitute.github.io/monster-helm
     alias: argoTemplates

--- a/orchestration/Chart.yaml
+++ b/orchestration/Chart.yaml
@@ -10,6 +10,6 @@ dependencies:
     repository: https://broadinstitute.github.io/monster-xml-to-json-list
     alias: xmlToJsonList
   - name: argo-templates
-    version: 1.2.3
+    version: 1.2.4
     repository: https://broadinstitute.github.io/monster-helm
     alias: argoTemplates

--- a/orchestration/templates/ingest-xml-archive.yaml
+++ b/orchestration/templates/ingest-xml-archive.yaml
@@ -207,7 +207,7 @@ spec:
                   value: {{ .accessKey.secretKey }}
                 {{- end }}
             {{- $existingFileId := "{{tasks.check-for-existing-file.outputs.result}}" }}
-            {{- $shouldIngestFile := printf "%s == null" $existingFileId }}
+            {{- $shouldIngestFile := printf "'%s' == null" $existingFileId }}
 
           # If we've already ingested a file, use it to ingest the matching row.
           - name: ingest-xml-archive-existing-file

--- a/orchestration/templates/ingest-xml-archive.yaml
+++ b/orchestration/templates/ingest-xml-archive.yaml
@@ -212,7 +212,7 @@ spec:
           # If we've already ingested a file, use it to ingest the matching row.
           - name: ingest-xml-archive-existing-file
             dependencies: [check-for-existing-file]
-            when: {{ (printf "%s != null" $existingFileId) | quote }}
+            when: {{ (printf "'%s' != null" $existingFileId) | quote }}
             template: ingest-xml-archive
             arguments:
               parameters:

--- a/orchestration/templates/ingest-xml-archive.yaml
+++ b/orchestration/templates/ingest-xml-archive.yaml
@@ -253,6 +253,7 @@ spec:
               template: main
             arguments:
               parameters:
+                {{ $gcsFilePath := printf "%s/xml/%s" $gcsPrefix (include "clinvar.raw-archive-name" .) | quote }}
                 {{- with .Values.jade }}
                 - name: url
                   value: {{ .url }}
@@ -272,7 +273,9 @@ spec:
                 - name: gcs-bucket
                   value: {{ .Values.staging.gcsBucket }}
                 - name: gcs-file-path
-                  value: {{ printf "%s/xml/%s" $gcsPrefix (include "clinvar.raw-archive-name" .) | quote }}
+                  value: {{ $gcsFilePath }}
+                - name: load-tag
+                  value: {{ $gcsFilePath }}
             {{- $newFileId := "{{tasks.ingest-archive.outputs.parameters.file-id}}" }}
 
           # Ingest a row for the new file.
@@ -342,6 +345,8 @@ spec:
                   value: {{ .accessKey.secretName }}
                 - name: sa-secret-key
                   value: {{ .accessKey.secretKey }}
+                - name: load-tag
+                  value: {{ .Values.staging.gcsBucket  }}
                 {{- end }}
 
     ##

--- a/orchestration/templates/ingest-xml-archive.yaml
+++ b/orchestration/templates/ingest-xml-archive.yaml
@@ -253,7 +253,7 @@ spec:
               template: main
             arguments:
               parameters:
-                {{ $gcsFilePath := printf "%s/xml/%s" $gcsPrefix (include "clinvar.raw-archive-name" .) | quote }}
+                {{- $gcsFilePath := printf "%s/xml/%s" $gcsPrefix (include "clinvar.raw-archive-name" .) | quote }}
                 {{- with .Values.jade }}
                 - name: url
                   value: {{ .url }}
@@ -345,8 +345,6 @@ spec:
                   value: {{ .accessKey.secretName }}
                 - name: sa-secret-key
                   value: {{ .accessKey.secretKey }}
-                - name: load-tag
-                  value: {{ .Values.staging.gcsBucket  }}
                 {{- end }}
 
     ##


### PR DESCRIPTION
## Why
We need to include a [load tag](https://github.com/databiosphere/stairway#concurrency) in our calls to jade's bulk ingest endpoint.

## This PR
* Creates a load tag that is the path to the daily file for ingest. This will prevent us from ingesting the same file simultaneously to Jade.