### PR TITLE
Set env var as a workaround for github action error

### DIFF
--- a/.github/workflows/build-and-publish-release.yaml
+++ b/.github/workflows/build-and-publish-release.yaml
@@ -33,6 +33,8 @@ jobs:
       - uses: broadinstitute/setup-chart-releaser@v1
         with:
           version: '1.0.0-beta.1'
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       - name: Publish
         run: sbt publish reindexHelmRepository
         env:

--- a/.github/workflows/build-and-publish-release.yaml
+++ b/.github/workflows/build-and-publish-release.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           version: '1.0.0-beta.1'
         env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       - name: Publish
         run: sbt publish reindexHelmRepository
         env:


### PR DESCRIPTION
## Why
We are unable to tag and release a clinvar version due to this [error](https://github.com/DataBiosphere/clinvar-ingest/actions/runs/501961762). 

## This PR
* Works around the issue with by setting a magic env var, until we can figure out a better fix.
