### PR TITLE
Upgrade ingest utils + scalafmt

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,4 +11,4 @@ resolvers += Resolver.url(
   new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
 )(publishPatterns)
 
-addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.0.1")
+addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.8")

--- a/transformation/src/main/scala/org/broadinstitute/monster/clinvar/parsers/Variation.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/clinvar/parsers/Variation.scala
@@ -38,71 +38,72 @@ object Variation {
   }
 
   /** Parser for "real" variation payloads, to be used in production. */
-  def parser(releaseDate: LocalDate): Parser = rawRecord => {
-    // Get the top-level variation.
-    val (rawVariation, variationType) = Constants.VariationTypes
-      .foldLeft(Option.empty[(Msg, String)]) { (acc, subtype) =>
-        acc.orElse(rawRecord.tryExtract[Msg](subtype).map(_ -> subtype))
-      }
-      .getOrElse {
-        throw new IllegalStateException(
-          s"Found a record with no variation: $rawRecord"
-        )
-      }
-    val topId = rawVariation.extract[String]("@VariationID")
+  def parser(releaseDate: LocalDate): Parser =
+    rawRecord => {
+      // Get the top-level variation.
+      val (rawVariation, variationType) = Constants.VariationTypes
+        .foldLeft(Option.empty[(Msg, String)]) { (acc, subtype) =>
+          acc.orElse(rawRecord.tryExtract[Msg](subtype).map(_ -> subtype))
+        }
+        .getOrElse {
+          throw new IllegalStateException(
+            s"Found a record with no variation: $rawRecord"
+          )
+        }
+      val topId = rawVariation.extract[String]("@VariationID")
 
-    // Extract gene info before parsing the rest of the variation so we can
-    // bundle all the unmodeled content at the end.
-    val (genes, geneAssociations) = rawVariation
-      .tryExtract[List[Msg]]("GeneList", "Gene")
-      .getOrElse(Nil)
-      .map { rawGene =>
-        val gene = Gene(
-          id = rawGene.extract[String]("@GeneID"),
+      // Extract gene info before parsing the rest of the variation so we can
+      // bundle all the unmodeled content at the end.
+      val (genes, geneAssociations) = rawVariation
+        .tryExtract[List[Msg]]("GeneList", "Gene")
+        .getOrElse(Nil)
+        .map { rawGene =>
+          val gene = Gene(
+            id = rawGene.extract[String]("@GeneID"),
+            releaseDate = releaseDate,
+            symbol = rawGene.tryExtract[String]("@Symbol"),
+            hgncId = rawGene.tryExtract[String]("@HGNC_ID"),
+            fullName = rawGene.tryExtract[String]("@FullName")
+          )
+          val geneAssociation = GeneAssociation(
+            geneId = gene.id,
+            variationId = topId,
+            releaseDate = releaseDate,
+            relationshipType = rawGene.tryExtract[String]("@RelationshipType"),
+            source = rawGene.tryExtract[String]("@Source"),
+            content = Content.encode(rawGene)
+          )
+          (gene, geneAssociation)
+        }
+        .unzip
+
+      val variation = {
+        val descendants = extractDescendantIds(rawVariation)
+
+        JadeVariation(
+          id = topId,
           releaseDate = releaseDate,
-          symbol = rawGene.tryExtract[String]("@Symbol"),
-          hgncId = rawGene.tryExtract[String]("@HGNC_ID"),
-          fullName = rawGene.tryExtract[String]("@FullName")
+          subclassType = variationType,
+          childIds = descendants.childIds,
+          descendantIds = (descendants.childIds ::: descendants.descendantIds),
+          name = rawVariation.tryExtract[String]("Name", "$"),
+          variationType = rawVariation
+            .tryExtract[Msg]("VariantType")
+            .orElse(rawVariation.tryExtract[Msg]("VariationType"))
+            .map(_.extract[String]("$")),
+          alleleId = rawVariation.tryExtract[String]("@AlleleID"),
+          proteinChange = rawVariation
+            .tryExtract[List[Msg]]("ProteinChange")
+            .getOrElse(List.empty)
+            .map(_.extract[String]("$")),
+          numChromosomes = rawVariation.tryExtract[Long]("@NumberOfChromosomes"),
+          numCopies = rawVariation.tryExtract[Long]("@NumberOfCopies"),
+          content = Content.encode(rawVariation)
         )
-        val geneAssociation = GeneAssociation(
-          geneId = gene.id,
-          variationId = topId,
-          releaseDate = releaseDate,
-          relationshipType = rawGene.tryExtract[String]("@RelationshipType"),
-          source = rawGene.tryExtract[String]("@Source"),
-          content = Content.encode(rawGene)
-        )
-        (gene, geneAssociation)
       }
-      .unzip
 
-    val variation = {
-      val descendants = extractDescendantIds(rawVariation)
-
-      JadeVariation(
-        id = topId,
-        releaseDate = releaseDate,
-        subclassType = variationType,
-        childIds = descendants.childIds,
-        descendantIds = (descendants.childIds ::: descendants.descendantIds),
-        name = rawVariation.tryExtract[String]("Name", "$"),
-        variationType = rawVariation
-          .tryExtract[Msg]("VariantType")
-          .orElse(rawVariation.tryExtract[Msg]("VariationType"))
-          .map(_.extract[String]("$")),
-        alleleId = rawVariation.tryExtract[String]("@AlleleID"),
-        proteinChange = rawVariation
-          .tryExtract[List[Msg]]("ProteinChange")
-          .getOrElse(List.empty)
-          .map(_.extract[String]("$")),
-        numChromosomes = rawVariation.tryExtract[Long]("@NumberOfChromosomes"),
-        numCopies = rawVariation.tryExtract[Long]("@NumberOfCopies"),
-        content = Content.encode(rawVariation)
-      )
+      Variation(variation, genes, geneAssociations)
     }
-
-    Variation(variation, genes, geneAssociations)
-  }
 
   /**
     * Descend the hierarchy of a variation payload to extract the IDs of its

--- a/transformation/src/test/scala/org/broadinstitute/monster/clinvar/ArchiveBranchesSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/clinvar/ArchiveBranchesSpec.scala
@@ -16,19 +16,20 @@ class ArchiveBranchesSpec extends PipelineSpec with PipelineCoders {
   it should "parse raw archives" in {
     val date = LocalDate.of(2020, 6, 23)
 
-    def parse(id: String) = VCV(
-      variation = Variation(
-        variation = JadeVariation.init(id, date, "type"),
-        genes = Nil,
-        associations = Nil
-      ),
-      vcv = None,
-      rcvs = Nil,
-      traitSets = Nil,
-      traits = Nil,
-      traitMappings = Nil,
-      scvs = Nil
-    )
+    def parse(id: String) =
+      VCV(
+        variation = Variation(
+          variation = JadeVariation.init(id, date, "type"),
+          genes = Nil,
+          associations = Nil
+        ),
+        vcv = None,
+        rcvs = Nil,
+        traitSets = Nil,
+        traits = Nil,
+        traitMappings = Nil,
+        scvs = Nil
+      )
 
     val fakeParser: VCV.Parser = rawArchive => {
       val id = rawArchive.read[String]("id")
@@ -49,23 +50,24 @@ class ArchiveBranchesSpec extends PipelineSpec with PipelineCoders {
   it should "dedup genes by date" in {
     val date = LocalDate.of(2020, 6, 23)
 
-    def parse(id: String) = VCV(
-      variation = Variation(
-        variation = JadeVariation.init(id, date, "type"),
-        genes = List(Gene.init(s"${id.toInt % 2}", date).copy(symbol = Some(id))),
-        associations = Nil
-      ),
-      vcv = Some(
-        VariationArchive
-          .init(id, date, 1L, id)
-          .copy(dateLastUpdated = Some(LocalDate.parse(f"2020-${id.toInt + 1}%02d-01")))
-      ),
-      rcvs = Nil,
-      traitSets = Nil,
-      traits = Nil,
-      traitMappings = Nil,
-      scvs = Nil
-    )
+    def parse(id: String) =
+      VCV(
+        variation = Variation(
+          variation = JadeVariation.init(id, date, "type"),
+          genes = List(Gene.init(s"${id.toInt % 2}", date).copy(symbol = Some(id))),
+          associations = Nil
+        ),
+        vcv = Some(
+          VariationArchive
+            .init(id, date, 1L, id)
+            .copy(dateLastUpdated = Some(LocalDate.parse(f"2020-${id.toInt + 1}%02d-01")))
+        ),
+        rcvs = Nil,
+        traitSets = Nil,
+        traits = Nil,
+        traitMappings = Nil,
+        scvs = Nil
+      )
 
     val fakeParser: VCV.Parser = rawArchive => {
       val id = rawArchive.read[String]("id")
@@ -89,23 +91,24 @@ class ArchiveBranchesSpec extends PipelineSpec with PipelineCoders {
   it should "dedup traits by date" in {
     val date = LocalDate.of(2020, 6, 23)
 
-    def parse(id: String) = VCV(
-      variation = Variation(
-        variation = JadeVariation.init(id, date, "type"),
-        genes = Nil,
-        associations = Nil
-      ),
-      vcv = Some(
-        VariationArchive
-          .init(id, date, 1L, id)
-          .copy(dateLastUpdated = Some(LocalDate.parse(f"2020-${id.toInt + 1}%02d-01")))
-      ),
-      rcvs = Nil,
-      traitSets = Nil,
-      traits = List(Trait.init(s"${id.toInt % 2}", date).copy(medgenId = Some(id))),
-      traitMappings = Nil,
-      scvs = Nil
-    )
+    def parse(id: String) =
+      VCV(
+        variation = Variation(
+          variation = JadeVariation.init(id, date, "type"),
+          genes = Nil,
+          associations = Nil
+        ),
+        vcv = Some(
+          VariationArchive
+            .init(id, date, 1L, id)
+            .copy(dateLastUpdated = Some(LocalDate.parse(f"2020-${id.toInt + 1}%02d-01")))
+        ),
+        rcvs = Nil,
+        traitSets = Nil,
+        traits = List(Trait.init(s"${id.toInt % 2}", date).copy(medgenId = Some(id))),
+        traitMappings = Nil,
+        scvs = Nil
+      )
 
     val fakeParser: VCV.Parser = rawArchive => {
       val id = rawArchive.read[String]("id")
@@ -129,23 +132,24 @@ class ArchiveBranchesSpec extends PipelineSpec with PipelineCoders {
   it should "dedup trait-sets by date" in {
     val date = LocalDate.of(2020, 6, 23)
 
-    def parse(id: String) = VCV(
-      variation = Variation(
-        variation = JadeVariation.init(id, date, "type"),
-        genes = Nil,
-        associations = Nil
-      ),
-      vcv = Some(
-        VariationArchive
-          .init(id, date, 1L, id)
-          .copy(dateLastUpdated = Some(LocalDate.parse(f"2020-${id.toInt + 1}%02d-01")))
-      ),
-      rcvs = Nil,
-      traitSets = List(TraitSet.init(s"${id.toInt % 2}", date).copy(`type` = Some(id))),
-      traits = Nil,
-      traitMappings = Nil,
-      scvs = Nil
-    )
+    def parse(id: String) =
+      VCV(
+        variation = Variation(
+          variation = JadeVariation.init(id, date, "type"),
+          genes = Nil,
+          associations = Nil
+        ),
+        vcv = Some(
+          VariationArchive
+            .init(id, date, 1L, id)
+            .copy(dateLastUpdated = Some(LocalDate.parse(f"2020-${id.toInt + 1}%02d-01")))
+        ),
+        rcvs = Nil,
+        traitSets = List(TraitSet.init(s"${id.toInt % 2}", date).copy(`type` = Some(id))),
+        traits = Nil,
+        traitMappings = Nil,
+        scvs = Nil
+      )
 
     val fakeParser: VCV.Parser = rawArchive => {
       val id = rawArchive.read[String]("id")
@@ -169,32 +173,33 @@ class ArchiveBranchesSpec extends PipelineSpec with PipelineCoders {
   it should "dedup submissions by date" in {
     val date = LocalDate.of(2020, 6, 23)
 
-    def parse(id: String) = VCV(
-      variation = Variation(
-        variation = JadeVariation.init(id, date, "type"),
-        genes = Nil,
-        associations = Nil
-      ),
-      vcv = None,
-      rcvs = Nil,
-      traitSets = Nil,
-      traits = Nil,
-      traitMappings = Nil,
-      scvs = List(
-        SCV(
-          assertion = ClinicalAssertion
-            .init(id, date, 1L, id, id, id, id, id)
-            .copy(dateLastUpdated = Some(LocalDate.parse(f"2020-${id.toInt + 1}%02d-01"))),
-          submitters = Nil,
-          submission = Submission
-            .init(s"${id.toInt % 2}", date, id, LocalDate.parse(f"2020-${id.toInt + 1}%02d-01")),
-          variations = Nil,
-          traitSets = Nil,
-          traits = Nil,
-          observations = Nil
+    def parse(id: String) =
+      VCV(
+        variation = Variation(
+          variation = JadeVariation.init(id, date, "type"),
+          genes = Nil,
+          associations = Nil
+        ),
+        vcv = None,
+        rcvs = Nil,
+        traitSets = Nil,
+        traits = Nil,
+        traitMappings = Nil,
+        scvs = List(
+          SCV(
+            assertion = ClinicalAssertion
+              .init(id, date, 1L, id, id, id, id, id)
+              .copy(dateLastUpdated = Some(LocalDate.parse(f"2020-${id.toInt + 1}%02d-01"))),
+            submitters = Nil,
+            submission = Submission
+              .init(s"${id.toInt % 2}", date, id, LocalDate.parse(f"2020-${id.toInt + 1}%02d-01")),
+            variations = Nil,
+            traitSets = Nil,
+            traits = Nil,
+            observations = Nil
+          )
         )
       )
-    )
 
     val fakeParser: VCV.Parser = rawArchive => {
       val id = rawArchive.read[String]("id")
@@ -225,41 +230,42 @@ class ArchiveBranchesSpec extends PipelineSpec with PipelineCoders {
   it should "aggregate names and abbreviations for submitters" in {
     val date = LocalDate.of(2020, 6, 23)
 
-    def parse(id: String) = VCV(
-      variation = Variation(
-        variation = JadeVariation.init(id, date, "type"),
-        genes = Nil,
-        associations = Nil
-      ),
-      vcv = None,
-      rcvs = Nil,
-      traitSets = Nil,
-      traits = Nil,
-      traitMappings = Nil,
-      scvs = List(
-        SCV(
-          assertion = ClinicalAssertion
-            .init(id, date, 1L, id, id, id, id, id)
-            .copy(dateLastUpdated = Some(LocalDate.parse(f"2020-${id.toInt + 1}%02d-01"))),
-          submitters = List(
-            Submitter
-              .init(s"${id.toInt % 2}", date)
-              .copy(
-                currentName = Some(id),
-                allNames = List(id),
-                currentAbbrev = Some(id),
-                allAbbrevs = List(id)
-              )
-          ),
-          submission = Submission
-            .init(s"${id.toInt % 2}", date, id, LocalDate.parse(f"2020-${id.toInt + 1}%02d-01")),
-          variations = Nil,
-          traitSets = Nil,
-          traits = Nil,
-          observations = Nil
+    def parse(id: String) =
+      VCV(
+        variation = Variation(
+          variation = JadeVariation.init(id, date, "type"),
+          genes = Nil,
+          associations = Nil
+        ),
+        vcv = None,
+        rcvs = Nil,
+        traitSets = Nil,
+        traits = Nil,
+        traitMappings = Nil,
+        scvs = List(
+          SCV(
+            assertion = ClinicalAssertion
+              .init(id, date, 1L, id, id, id, id, id)
+              .copy(dateLastUpdated = Some(LocalDate.parse(f"2020-${id.toInt + 1}%02d-01"))),
+            submitters = List(
+              Submitter
+                .init(s"${id.toInt % 2}", date)
+                .copy(
+                  currentName = Some(id),
+                  allNames = List(id),
+                  currentAbbrev = Some(id),
+                  allAbbrevs = List(id)
+                )
+            ),
+            submission = Submission
+              .init(s"${id.toInt % 2}", date, id, LocalDate.parse(f"2020-${id.toInt + 1}%02d-01")),
+            variations = Nil,
+            traitSets = Nil,
+            traits = Nil,
+            observations = Nil
+          )
         )
       )
-    )
 
     val fakeParser: VCV.Parser = rawArchive => {
       val id = rawArchive.read[String]("id")


### PR DESCRIPTION
## Why
The Oracle graalvm-ce image we were using is no longer accessible, so we cannot publish a clinvar release.

## This PR
* Upgrades to ingest-utils 2.1.8 which points to an updated image
* I believe our formatting settings changed between the previous version of ingest-utils and 2.1.8, hence the 4 reformatted files.