### PR TITLE
Override the docker image we are using to build the pipeline

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,9 @@ lazy val `clinvar-transformation-pipeline` = project
   .in(file("transformation"))
   .enablePlugins(MonsterScioPipelinePlugin)
   .dependsOn(`clinvar-schema`)
+  .settings(
+    dockerBaseImage := "ghcr.io/graalvm/graalvm-ce:ol7-java8-20.3.1"
+  )
 
 lazy val `clinvar-orchestration-workflow` = project
   .in(file("orchestration"))


### PR DESCRIPTION
## Why
We cannot publish a docker container for this pipeline due to the needed docker image being unavailable. Upgrading ingest-utils to 2.1.8 causes codegen issues on our usage of the scala reserved keyword `trait` for one of the entities we model. Until we can figure _that_ out, let's try just overriding the docker image in the build.sbt settings.

## This PR
* Overrides the `dockerBaseImage` setting to point at the CE graalvm image.