### PR TITLE
Upgrade monster-xml-to-json to workaround large attribute issue

### DIFF
--- a/orchestration/Chart.yaml
+++ b/orchestration/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 version: 0.0.0
 dependencies:
   - name: xml-to-json-list-template
-    version: 3.3.2
+    version: 3.3.3
     repository: https://broadinstitute.github.io/monster-xml-to-json-list
     alias: xmlToJsonList
   - name: argo-templates

--- a/orchestration/Chart.yaml
+++ b/orchestration/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 version: 0.0.0
 dependencies:
   - name: xml-to-json-list-template
-    version: 3.3.3
+    version: 3.3.4
     repository: https://broadinstitute.github.io/monster-xml-to-json-list
     alias: xmlToJsonList
   - name: argo-templates

--- a/orchestration/Chart.yaml
+++ b/orchestration/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 version: 0.0.0
 dependencies:
   - name: xml-to-json-list-template
-    version: 3.3.1
+    version: 3.3.2
     repository: https://broadinstitute.github.io/monster-xml-to-json-list
     alias: xmlToJsonList
   - name: argo-templates


### PR DESCRIPTION
## Why
We are encountering problems parsing the latest XML release file from clinvar, due to a large attribute.

## This PR
* Pulls in an upgraded monster-xml-to-json version that bumps the attribute size limit. 