### PR TITLE
[DSPDC-1634] Add version to where clause when checking for processing history rows

### DIFF
--- a/orchestration/scripts/count-processing-history-rows.sh
+++ b/orchestration/scripts/count-processing-history-rows.sh
@@ -12,4 +12,4 @@ declare -ra BQ_QUERY=(
 )
 declare -r TABLE="\`${JADE_PROJECT}.${JADE_DATASET}.processing_history\`"
 
-${BQ_QUERY[@]} "SELECT COUNT(1) FROM ${TABLE} WHERE release_date = '${RELEASE_DATE}'" | tail -n 1
+${BQ_QUERY[@]} "SELECT COUNT(1) FROM ${TABLE} WHERE release_date = '${RELEASE_DATE}' AND pipeline_version = '${VERSION}" | tail -n 1

--- a/orchestration/scripts/count-processing-history-rows.sh
+++ b/orchestration/scripts/count-processing-history-rows.sh
@@ -12,4 +12,4 @@ declare -ra BQ_QUERY=(
 )
 declare -r TABLE="\`${JADE_PROJECT}.${JADE_DATASET}.processing_history\`"
 
-${BQ_QUERY[@]} "SELECT COUNT(1) FROM ${TABLE} WHERE release_date = '${RELEASE_DATE}' AND pipeline_version = '${VERSION}" | tail -n 1
+${BQ_QUERY[@]} "SELECT COUNT(1) FROM ${TABLE} WHERE release_date = '${RELEASE_DATE}' AND pipeline_version = '${VERSION}'" | tail -n 1

--- a/orchestration/templates/date-present.yaml
+++ b/orchestration/templates/date-present.yaml
@@ -257,7 +257,7 @@ spec:
             value: UPDATE
         command: ["python", "-c", "import diff; diff.get_updated_rows()"]
 
-      - name: export-rows
+    - name: export-rows
       inputs:
         parameters:
           - name: table-name

--- a/orchestration/templates/date-present.yaml
+++ b/orchestration/templates/date-present.yaml
@@ -257,7 +257,7 @@ spec:
             value: UPDATE
         command: ["python", "-c", "import diff; diff.get_updated_rows()"]
 
-    - name: export-rows
+      - name: export-rows
       inputs:
         parameters:
           - name: table-name


### PR DESCRIPTION
## Why
If processing fails after data is ingested but before we cut a snapshot (i.e., jade 500s on the snapshot create),
a subsequent retry cannot proceed to the snapshotting test as the current check detects an existing processing_history
row and ends the ingestion job.

## This PR
Adds a check against version as well as release date; if it misses, it will proceeded with the reingest and cut the snapshot
