### PR TITLE
ra dspdc 1656 remove version pin snapshot

### DIFF
--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -74,7 +74,7 @@ spec:
 
           # If we have provenance information, cut a snapshot of the new data
           # for the release-date.
-          {{- if $versionIsPinned }}
+
           - name: publish-processing-results
             dependencies: [ingest-archive]
             when: {{ $processingNeeded | quote }}
@@ -91,7 +91,7 @@ spec:
           - name: check-latest-snapshot
             dependencies: [publish-processing-results]
             template: check-latest-snapshot
-          {{- end }}
+
       outputs:
         parameters:
           - name: dataset-name


### PR DESCRIPTION
## Why
We can't test the latest change in dev, and we don't want to test it in prod. [Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1656).

## This PR
Removes the template if statement for checking if the version is pinned specifically for snapshot creation and checking.