### PR TITLE
DSPDC-1659 Fix dev ingest

### DIFF
--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -74,7 +74,7 @@ spec:
 
           # If we have provenance information, cut a snapshot of the new data
           # for the release-date.
-
+          {{- if $versionIsPinned }}
           - name: publish-processing-results
             dependencies: [ingest-archive]
             when: {{ $processingNeeded | quote }}
@@ -91,7 +91,7 @@ spec:
           - name: check-latest-snapshot
             dependencies: [publish-processing-results]
             template: check-latest-snapshot
-
+          {{- end }}
       outputs:
         parameters:
           - name: dataset-name


### PR DESCRIPTION
## Why
We removed the check for `versionIsPinned` in a few places in the ingestion pipeline, but there are a few more that need to be removed as they produce output that is needed downstream. Because of the incomplete removal, we are missing needed output and bumping into a template render error captured in this ticket [here](https://broadinstitute.atlassian.net/browse/DSPDC-1659)

## This PR
* Reverts DataBiosphere/clinvar-ingest#85 until we can figure out a better approach