### PR TITLE
Ra dspdc 1626 snapshot bug

### DIFF
--- a/docker/check-snapshot/build.sh
+++ b/docker/check-snapshot/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-declare -r VERSION=0.1.1
+declare -r VERSION=0.1.2
 
 docker build -t us.gcr.io/broad-dsp-gcr-public/monster-check-snapshot:${VERSION} .
 docker push us.gcr.io/broad-dsp-gcr-public/monster-check-snapshot:${VERSION}

--- a/docker/check-snapshot/build.sh
+++ b/docker/check-snapshot/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-declare -r VERSION=0.1.0
+declare -r VERSION=0.1.1
 
 docker build -t us.gcr.io/broad-dsp-gcr-public/monster-check-snapshot:${VERSION} .
 docker push us.gcr.io/broad-dsp-gcr-public/monster-check-snapshot:${VERSION}

--- a/docker/check-snapshot/build.sh
+++ b/docker/check-snapshot/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-declare -r VERSION=0.1.2
+declare -r VERSION=0.1.3
 
 docker build -t us.gcr.io/broad-dsp-gcr-public/monster-check-snapshot:${VERSION} .
 docker push us.gcr.io/broad-dsp-gcr-public/monster-check-snapshot:${VERSION}

--- a/docker/check-snapshot/check.py
+++ b/docker/check-snapshot/check.py
@@ -52,10 +52,14 @@ def check_snapshot_exists(host: str, dataset_id: str, filter: str) -> None:
     jade_client = get_api_client(host=host)
     r = jade_client.enumerate_snapshots(
         limit=1,sort="created_date", direction="desc", dataset_ids=[dataset_id], filter=filter)
-    assert r.total == 1, "No snapshot found for latest release date in xml_archive table"
+    if r.total == 0:
+        logging.info("No snapshot found for latest release date in xml_archive table")
+    else:
+        logging.info(f"Found {r.total} snapshot(s) for latest release date in xml_archive table")
+    return r.total
 
 def run():
     latest_release_date = get_latest_xml_release_date(project=google_project, dataset=dataset_name)
     logging.info(f"Latest release date in XML archive is {latest_release_date}")
-    check_snapshot_exists(host=data_repo_host, dataset_id=dataset_id, filter=latest_release_date)
+    return check_snapshot_exists(host=data_repo_host, dataset_id=dataset_id, filter=latest_release_date)
 

--- a/docker/check-snapshot/check.py
+++ b/docker/check-snapshot/check.py
@@ -18,7 +18,7 @@ dataset_id = os.getenv("REPO_DATASET_ID")
 
 def default_google_access_token():
     # get token for google-based auth use, assumes application default credentials work for specified environment
-    credentials, _ = google.auth.default()
+    credentials, _ = google.auth.default(scopes=['openid', 'email', 'profile'])
     credentials.refresh(Request())
 
     return credentials.token

--- a/docker/check-snapshot/check.py
+++ b/docker/check-snapshot/check.py
@@ -48,7 +48,7 @@ def get_latest_xml_release_date(project: str, dataset: str) -> str:
     cleaned_date = str(release_date).replace("-", "_")
     return cleaned_date
 
-def check_snapshot_exists(host: str, dataset_id: str, filter: str) -> None:
+def check_snapshot_exists(host: str, dataset_id: str, filter: str) -> int:
     jade_client = get_api_client(host=host)
     r = jade_client.enumerate_snapshots(
         limit=1,sort="created_date", direction="desc", dataset_ids=[dataset_id], filter=filter)
@@ -61,5 +61,7 @@ def check_snapshot_exists(host: str, dataset_id: str, filter: str) -> None:
 def run():
     latest_release_date = get_latest_xml_release_date(project=google_project, dataset=dataset_name)
     logging.info(f"Latest release date in XML archive is {latest_release_date}")
-    return check_snapshot_exists(host=data_repo_host, dataset_id=dataset_id, filter=latest_release_date)
+    output = check_snapshot_exists(host=data_repo_host, dataset_id=dataset_id, filter=latest_release_date)
+    # print the output to stdout because argo
+    print(output)
 

--- a/orchestration/scripts/request-release-date-snapshot.py
+++ b/orchestration/scripts/request-release-date-snapshot.py
@@ -11,7 +11,7 @@ credentials, project = google.auth.default(scopes=['openid', 'email', 'profile']
 base_url = os.environ["API_URL"]
 dataset_name = os.environ["DATASET_NAME"]
 profile_id = os.environ["PROFILE_ID"]
-reader_email = os.environ["READER_EMAIL"]
+environment = os.environ["ENVIRONMENT"]
 
 asset_name = os.environ["ASSET_NAME"]
 release_date = os.environ["RELEASE_DATE"]
@@ -44,5 +44,7 @@ snapshot_contents = [{
   }
 }]
 
-job_id = submit_snapshot(name=snapshot_name, description=snapshot_description, contents=snapshot_contents, profileId=profile_id, readers=[reader_email])
+reader_emails = ["clingendevs@firecloud.org"] if environment == "prod" else []
+
+job_id = submit_snapshot(name=snapshot_name, description=snapshot_description, contents=snapshot_contents, profileId=profile_id, readers=reader_emails)
 print(job_id)

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -301,7 +301,10 @@ spec:
             value: {{ .Values.jade.url }}
           - name: REPO_DATASET_ID
             value: {{ .Values.jade.datasetId }}
-        command: ["python", "-c", "import check; check.run()"]
+        command: [python]
+        source: |
+          import check
+          check.run()
 
     ##
     ## Publish the data stored in the TDR under a release-date by marking

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -81,7 +81,7 @@ spec:
           - name: publish-processing-results
             dependencies: [check-latest-snapshot]
             # only publish results when processing is needed and a snapshot is needed
-            when: {{ "({{tasks.check-processing-history.outputs.result}} == 0) && ({{tasks.check-latest-snapshot.outputs.result}} == 0)" }}
+            when: {{ "({{tasks.check-latest-snapshot.outputs.result}} == 0)" }}
             template: publish-processing-results
             arguments:
               parameters:

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -72,12 +72,19 @@ spec:
                   value: {{ $gcsPrefix | quote }}
             {{- $stagingDataset := "{{tasks.ingest-archive.outputs.parameters.dataset-name}}" }}
 
-          # If we have provenance information, cut a snapshot of the new data
+          # If we have provenance information and a snapshot doesn't exist, cut a snapshot of the new data
           # for the release-date.
           {{- if $versionIsPinned }}
-          - name: publish-processing-results
+          - name: check-latest-snapshot
             dependencies: [ingest-archive]
-            when: {{ $processingNeeded | quote }}
+            template: check-latest-snapshot
+          - name: publish-processing-results
+            dependencies: [check-latest-snapshot]
+            # only publish results when processing is needed and a snapshot is needed
+            when: >-
+              ( {{tasks.check-processing-history.outputs.result}} == 0 &&
+                {{tasks.check-latest-snapshot.outputs.result}} == 0
+              )
             template: publish-processing-results
             arguments:
               parameters:
@@ -87,10 +94,6 @@ spec:
                   value: {{ $gcsPrefix | quote }}
                 - name: bq-dataset
                   value: {{ $stagingDataset | quote }}
-
-          - name: check-latest-snapshot
-            dependencies: [publish-processing-results]
-            template: check-latest-snapshot
           {{- end }}
       outputs:
         parameters:
@@ -286,7 +289,7 @@ spec:
           secret:
             secretName: {{ .Values.jade.accessKey.secretName }}
       script:
-        image: us.gcr.io/broad-dsp-gcr-public/monster-check-snapshot:0.1.1
+        image: us.gcr.io/broad-dsp-gcr-public/monster-check-snapshot:0.1.2
         volumeMounts:
           - name: sa-secret-volume
             mountPath: /secret

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -286,7 +286,7 @@ spec:
           secret:
             secretName: {{ .Values.jade.accessKey.secretName }}
       script:
-        image: us.gcr.io/broad-dsp-gcr-public/monster-check-snapshot:0.1.2
+        image: us.gcr.io/broad-dsp-gcr-public/monster-check-snapshot:0.1.3
         volumeMounts:
           - name: sa-secret-volume
             mountPath: /secret
@@ -301,10 +301,7 @@ spec:
             value: {{ .Values.jade.url }}
           - name: REPO_DATASET_ID
             value: {{ .Values.jade.datasetId }}
-        command: [python]
-        source: |
-          import check
-          check.run()
+        command: ["python", "-c", "import check; check.run()"]
 
     ##
     ## Publish the data stored in the TDR under a release-date by marking

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -81,10 +81,7 @@ spec:
           - name: publish-processing-results
             dependencies: [check-latest-snapshot]
             # only publish results when processing is needed and a snapshot is needed
-            when: >-
-              ( {{tasks.check-processing-history.outputs.result}} == 0 &&
-                {{tasks.check-latest-snapshot.outputs.result}} == 0
-              )
+            when: {{ "({{tasks.check-processing-history.outputs.result}} == 0) && ({{tasks.check-latest-snapshot.outputs.result}} == 0)" }}
             template: publish-processing-results
             arguments:
               parameters:

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -286,7 +286,7 @@ spec:
           secret:
             secretName: {{ .Values.jade.accessKey.secretName }}
       script:
-        image: us.gcr.io/broad-dsp-gcr-public/monster-check-snapshot:0.1.0
+        image: us.gcr.io/broad-dsp-gcr-public/monster-check-snapshot:0.1.1
         volumeMounts:
           - name: sa-secret-volume
             mountPath: /secret

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -450,8 +450,8 @@ spec:
             value: {{ $releaseDate | quote }}
           - name: PIPELINE_VERSION
             value: {{ $pipelineVersion }}
-          - name: READER_EMAIL
-            value: clingendevs@firecloud.org
+          - name: ENVIRONMENT
+            value: {{ .Values.jade.environment }}
         command: [python]
         source: |
         {{- include "argo.render-lines" (.Files.Lines "scripts/request-release-date-snapshot.py") | indent 10 }}


### PR DESCRIPTION
## Why
We took measures to add snapshot creation to our clinvar dev deployment, but it still has issues. We need to ensure snapshot creation works and works in a resilient manner.

## This PR
Adds a snapshot-existence check and adds it to the workflow. A snapshot is only created if one does not already exist; if it does, the code path to create a snapshot is not executed. This logic helps if we enter a bad state where "processing" (aka the dataflow pipeline) has run but snapshot creation had previously failed.