### PR TITLE
[DSPDC-1858] Workaround jade API change

### DIFF
--- a/docker/check-snapshot/check.py
+++ b/docker/check-snapshot/check.py
@@ -50,7 +50,7 @@ def get_latest_xml_release_date(project: str, dataset: str) -> str:
 
 
 def get_api_credentials():
-    creds, _ = google.auth.default(scopes=['openid', 'email', 'profile', 'https://www.googleapis.com/auth/cloud-platform'])  # type: ignore # (unannotated library)
+    creds, _ = google.auth.default(scopes=['openid', 'email', 'profile', 'https://www.googleapis.com/auth/cloud-platform'])
     creds.refresh(Request())
     return creds
 

--- a/docker/check-snapshot/check.py
+++ b/docker/check-snapshot/check.py
@@ -5,7 +5,7 @@ from data_repo_client import ApiClient, Configuration, RepositoryApi
 import google.auth
 from google.auth.transport.requests import Request
 from google.cloud import bigquery
-
+import requests
 
 logging.basicConfig(level=logging.INFO)
 
@@ -48,15 +48,27 @@ def get_latest_xml_release_date(project: str, dataset: str) -> str:
     cleaned_date = str(release_date).replace("-", "_")
     return cleaned_date
 
+
+def get_api_credentials():
+    creds, _ = google.auth.default(scopes=['openid', 'email', 'profile', 'https://www.googleapis.com/auth/cloud-platform'])  # type: ignore # (unannotated library)
+    creds.refresh(Request())
+    return creds
+
+
 def check_snapshot_exists(host: str, dataset_id: str, filter: str) -> int:
-    jade_client = get_api_client(host=host)
-    r = jade_client.enumerate_snapshots(
-        limit=1,sort="created_date", direction="desc", dataset_ids=[dataset_id], filter=filter)
-    if r.total == 0:
+    creds = get_api_credentials()
+    enumerate_snapshots_url = f"{host}/api/repository/v1/snapshots?datasetIds={dataset_id}&direction=asc&filter={filter}&limit=10&offset=0&sort=created_date"
+    response = requests.get(enumerate_snapshots_url, headers={
+        "Authorization": f"Bearer {creds.token}"
+    }).json()
+
+    filtered_total = response['filteredTotal']
+    if filtered_total == 0:
         logging.info("No snapshot found for latest release date in xml_archive table")
     else:
-        logging.info(f"Found {r.total} snapshot(s) for latest release date in xml_archive table")
-    return r.total
+        logging.info(f"Found {filtered_total} snapshot(s) for latest release date in xml_archive table")
+    return filtered_total
+
 
 def run():
     latest_release_date = get_latest_xml_release_date(project=google_project, dataset=dataset_name)
@@ -65,3 +77,6 @@ def run():
     # print the output to stdout because argo
     print(output)
 
+
+if __name__ == '__main__':
+    run()

--- a/docker/check-snapshot/requirements.txt
+++ b/docker/check-snapshot/requirements.txt
@@ -1,2 +1,3 @@
 data-repo-client
 google-cloud-bigquery
+requests


### PR DESCRIPTION
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1858)
The semantics of the `total` field has changed in the Jade API `enumerateSnapshots` response. Before it reflected the total _after_ filtering, it now reflects the total available. There is a new field, `filteredTotal` that we should begin using.

Since the currently published version of the Jade API client does not support this new field and the clinvar ingest is blocked until we get this resolved, I have switched to making a raw HTTP request via the python `reequests` library.

I have tested this locally using the prod argo config and credentials, no errors and the result is what we expect.
