### PR TITLE
[DSPDC-1858] Bump check script dockerfile version

### DIFF
--- a/docker/check-snapshot/build.sh
+++ b/docker/check-snapshot/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-declare -r VERSION=0.1.3
+declare -r VERSION=0.1.4
 
 docker build -t us.gcr.io/broad-dsp-gcr-public/monster-check-snapshot:${VERSION} .
 docker push us.gcr.io/broad-dsp-gcr-public/monster-check-snapshot:${VERSION}

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -287,7 +287,7 @@ spec:
           secret:
             secretName: {{ .Values.jade.accessKey.secretName }}
       script:
-        image: us.gcr.io/broad-dsp-gcr-public/monster-check-snapshot:0.1.3
+        image: us.gcr.io/broad-dsp-gcr-public/monster-check-snapshot:0.1.4
         volumeMounts:
           - name: sa-secret-volume
             mountPath: /secret


### PR DESCRIPTION
This docker image needs an image bump and the corresponding workflow needs to point at the new version for the code to take effect.