### PR TITLE
[DSPDC-1864] Pull in argo templates with bq 502 fix

### DIFF
--- a/orchestration/Chart.yaml
+++ b/orchestration/Chart.yaml
@@ -10,6 +10,6 @@ dependencies:
     repository: https://broadinstitute.github.io/monster-xml-to-json-list
     alias: xmlToJsonList
   - name: argo-templates
-    version: 1.2.4
+    version: 1.2.6
     repository: https://broadinstitute.github.io/monster-helm
     alias: argoTemplates


### PR DESCRIPTION
This pulls in the BQ 502 retries implemented in [this PR](https://github.com/broadinstitute/monster-helm/pull/47). 