### PR TITLE
[DSPDC-1861] Put onExit hook inside of template, add retries

### DIFF
--- a/.github/workflows/build-and-publish-release.yaml
+++ b/.github/workflows/build-and-publish-release.yaml
@@ -4,8 +4,6 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
       - v[0-9]+.[0-9]+.[0-9]+-**
-    branches:
-      - arh-snapshot-failures-retry
 jobs:
   publish-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-publish-release.yaml
+++ b/.github/workflows/build-and-publish-release.yaml
@@ -4,6 +4,8 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
       - v[0-9]+.[0-9]+.[0-9]+-**
+    branches:
+      - arh-snapshot-failures-retry
 jobs:
   publish-release:
     runs-on: ubuntu-latest

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -103,8 +103,6 @@ spec:
     ## Sync the JSON outputs of Dataflow processing into the TDR.
     ##
     - name: ingest-archive
-      ## TODO ARH testing, remove this notification
-      onExit: send-slack-notification
       inputs:
         parameters:
           - name: gcs-prefix

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -76,7 +76,6 @@ spec:
           # for the release-date.
           {{- if $versionIsPinned }}
           - name: check-latest-snapshot
-            {{- include "argo.retry" . | indent 6 }}
             dependencies: [ingest-archive]
             template: check-latest-snapshot
           - name: publish-processing-results
@@ -288,6 +287,7 @@ spec:
         - name: sa-secret-volume
           secret:
             secretName: {{ .Values.jade.accessKey.secretName }}
+      {{- include "argo.retry" . | indent 6 }}
       script:
         image: us.gcr.io/broad-dsp-gcr-public/monster-check-snapshot:0.1.4
         volumeMounts:
@@ -347,7 +347,6 @@ spec:
                   value: {{ $releaseDate | quote }}
 
           - name: submit-snapshot
-            {{- include "argo.retry" . | indent 6 }}
             dependencies: [sync-processing-history]
             template: submit-snapshot
             arguments:
@@ -357,7 +356,6 @@ spec:
             {{- $jobId := "{{tasks.submit-snapshot.outputs.result}}" }}
 
           - name: poll-snapshot
-            {{- include "argo.retry" . | indent 6 }}
             dependencies: [submit-snapshot]
             template: poll-ingest-job
             arguments:
@@ -426,6 +424,7 @@ spec:
     ## a given ClinVar release date.
     ##
     - name: submit-snapshot
+      {{- include "argo.retry" . | indent 6 }}
       inputs:
         parameters:
           - name: release-date

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -104,6 +104,8 @@ spec:
     ## Sync the JSON outputs of Dataflow processing into the TDR.
     ##
     - name: ingest-archive
+      ## TODO ARH testing, remove this notification
+      onExit: send-slack-notification
       inputs:
         parameters:
           - name: gcs-prefix

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -76,6 +76,7 @@ spec:
           # for the release-date.
           {{- if $versionIsPinned }}
           - name: check-latest-snapshot
+            {{- include "argo.retry" . | indent 6 }}
             dependencies: [ingest-archive]
             template: check-latest-snapshot
           - name: publish-processing-results
@@ -83,7 +84,6 @@ spec:
             # only publish results when processing is needed and a snapshot is needed
             when: {{ "({{tasks.check-latest-snapshot.outputs.result}} == 0)" }}
             template: publish-processing-results
-            onExit: send-slack-notification
             arguments:
               parameters:
                 - name: release-date
@@ -310,6 +310,7 @@ spec:
     ## snapshot.
     ##
     - name: publish-processing-results
+      onExit: send-slack-notification
       inputs:
         parameters:
           - name: release-date
@@ -344,6 +345,7 @@ spec:
                   value: {{ $releaseDate | quote }}
 
           - name: submit-snapshot
+            {{ - include "argo.retry" . | indent 6 }}
             dependencies: [sync-processing-history]
             template: submit-snapshot
             arguments:
@@ -353,6 +355,7 @@ spec:
             {{- $jobId := "{{tasks.submit-snapshot.outputs.result}}" }}
 
           - name: poll-snapshot
+            {{- include "argo.retry" . | indent 6 }}
             dependencies: [submit-snapshot]
             template: poll-ingest-job
             arguments:

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -347,7 +347,7 @@ spec:
                   value: {{ $releaseDate | quote }}
 
           - name: submit-snapshot
-            {{ - include "argo.retry" . | indent 6 }}
+            {{- include "argo.retry" . | indent 6 }}
             dependencies: [sync-processing-history]
             template: submit-snapshot
             arguments:


### PR DESCRIPTION
## Why
The clinvar ingest fails to notify when a snapshot is cut, and also fails out when Jade gives back a 500 during the snapshotting process.

## This PR
* Moves the slack notification for a new snapshot into the template itself, instead of the callsite. 
* Adds argo retries around the Jade check latest snapshot and submit snapshot calls. I'd like to add a retry to the poll snapshot piece as well, but that is brought in via monster-helm and will need to be a PR in that repo.