### PR TITLE
[DSPDC-1895] Retry on poll 5xx from Jade

### DIFF
--- a/orchestration/scripts/poll-ingest-job.py
+++ b/orchestration/scripts/poll-ingest-job.py
@@ -19,6 +19,9 @@ def check_job_status(job_id: str):
     response = authed_session.get(f"{base_url}/api/repository/v1/jobs/{job_id}")
     if response.ok:
         return response.json()["job_status"]
+    elif 499 < response.status_code < 599:
+        print(f"Received status code {response.status_code} from TDR")
+        return "internal_error"
     else:
         raise HTTPError("Bad response, got code of: {}".format(response.status_code))
 

--- a/orchestration/scripts/poll-ingest-job.py
+++ b/orchestration/scripts/poll-ingest-job.py
@@ -20,7 +20,7 @@ def check_job_status(job_id: str):
     if response.ok:
         return response.json()["job_status"]
     elif 499 < response.status_code < 599:
-        print(f"Received status code {response.status_code} from TDR")
+        print(f"Received status code '{response.status_code}' from TDR")
         return "internal_error"
     else:
         raise HTTPError("Bad response, got code of: {}".format(response.status_code))
@@ -31,6 +31,7 @@ def is_done(job_id: str) -> bool:
     # if "succeeded" then we want to stop polling, so true
     # if "failed" then we want to stop polling, so true
     status = check_job_status(job_id)
+    print(f"Received status code '{status}' for job_id {job_id}")
     return status in ["succeeded", "failed"]
 
 


### PR DESCRIPTION
The polling endpoint is intermittently 502ing, causing the overall job to hang. Given that this is usually a transient condition, we should accept 5XX status codes and retry.