### PR TITLE
Fix templating for shouldExportDiffs var

### DIFF
--- a/orchestration/templates/ingest-clinvar-release-e2e.yaml
+++ b/orchestration/templates/ingest-clinvar-release-e2e.yaml
@@ -45,10 +45,10 @@ spec:
                 - name: gcs-prefix
                   value: {{ $gcsPrefix | quote }}
             {{- $datasetName := "{{tasks.process-archive.outputs.parameters.dataset-name}}" }}
-          {{- $shouldExportDiff := "{{ .Values.steps.exportDiff.enabled }}" }}
+          {{- $shouldExportDiff := printf "%t" .Values.steps.exportDiff.enabled }}
 
           - name: export-diff
-            when: {{ printf "%s == true" $shouldExportDiff | quote }}
+            when: {{ printf "%s == true" $shouldExportDiff }}
             dependencies: [process-archive]
             templateRef:
               name: export-diff


### PR DESCRIPTION
The templating for the `shouldExportDiffs` variable was not rendering properly during testing in dev. I've verified that this renders correctly.
