### PR TITLE
Parameterize Jade connection information

### DIFF
--- a/orchestration/example-values/no-version.yaml
+++ b/orchestration/example-values/no-version.yaml
@@ -5,6 +5,15 @@ staging:
     datasetPrefix: monster_staging_data
     description: ClinVar!!!
     expiration: '604800'
+altJade:
+  url: http://other.repo
+  datasetId: a
+  datasetName: clinvar
+  profileId: b
+  dataProject: dataaaaa
+  accessKey:
+    secretName: dont-tell
+    secretKey: its-a-secret
 jade:
   url: http://jade.repo
   datasetId: a
@@ -30,6 +39,7 @@ dataflow:
   subnetName: network
   workerAccount: runner@zoog
 notification:
+  altChannelId: othertest
   channelId: monstertest
   onlyOnFailure: false
   oauthToken:

--- a/orchestration/example-values/no-version.yaml
+++ b/orchestration/example-values/no-version.yaml
@@ -45,6 +45,3 @@ notification:
   oauthToken:
     secretName: aaaaa
     secretKey: bbbbb
-steps:
-  exportDiff:
-    enabled: true

--- a/orchestration/example-values/pinned-version.yaml
+++ b/orchestration/example-values/pinned-version.yaml
@@ -49,6 +49,3 @@ notification:
   oauthToken:
     secretName: aaaaa
     secretKey: bbbbb
-steps:
-  exportDiff:
-    enabled: true

--- a/orchestration/example-values/pinned-version.yaml
+++ b/orchestration/example-values/pinned-version.yaml
@@ -6,6 +6,15 @@ staging:
     datasetPrefix: monster_staging_data
     description: ClinVar!!!
     expiration: '604800'
+altJade:
+  url: http://other.repo
+  datasetId: a
+  datasetName: clinvar
+  profileId: b
+  dataProject: dataaaaa
+  accessKey:
+    secretName: dont-tell
+    secretKey: its-a-secret
 jade:
   url: http://jade.repo
   datasetId: a
@@ -34,6 +43,7 @@ argoTemplates:
   diffBQTable:
     schemaImageVersion: adsaasdf
 notification:
+  altChannelId: othertest
   channelId: monstertest
   onlyOnFailure: true
   oauthToken:

--- a/orchestration/scripts/get-archive-property.sh
+++ b/orchestration/scripts/get-archive-property.sh
@@ -12,4 +12,6 @@ declare -ra BQ_QUERY=(
 )
 declare -r TABLE="\`${JADE_PROJECT}.${JADE_DATASET}.xml_archive\`"
 
-${BQ_QUERY[@]} "SELECT ${PROPERTY} FROM ${TABLE} WHERE release_date = '${RELEASE_DATE}'" | tail -n 1
+# ${BQ_QUERY[@]} "SELECT ${PROPERTY} FROM ${TABLE} WHERE release_date = '${RELEASE_DATE}'" | tail -n 1
+
+${BQ_QUERY[@]} "SELECT ${PROPERTY} FROM ${TABLE} WHERE release_date = '${RELEASE_DATE}'"

--- a/orchestration/templates/cron-workflow.yaml
+++ b/orchestration/templates/cron-workflow.yaml
@@ -32,6 +32,8 @@ spec:
                     value: URL
                   - name: dataset-id
                     value: FOO
+                  - name: dataset-name
+                    value: FOO
                   - name: archive-path
                     value: weekly_release/ClinVarVariationRelease_00-latest_weekly.xml.gz
                   - name: gcs-prefix

--- a/orchestration/templates/cron-workflow.yaml
+++ b/orchestration/templates/cron-workflow.yaml
@@ -28,6 +28,8 @@ spec:
                 template: main
               arguments:
                 parameters:
+                  - name: data-repo-url
+                    value: URL
                   - name: dataset-id
                     value: FOO
                   - name: archive-path

--- a/orchestration/templates/cron-workflow.yaml
+++ b/orchestration/templates/cron-workflow.yaml
@@ -42,6 +42,8 @@ spec:
                     value: weekly_release/ClinVarVariationRelease_00-latest_weekly.xml.gz
                   - name: gcs-prefix
                     value: {{ include "argo.timestamp" . | quote }}
+                  - name: should-export-diff
+                    value: true
 
       ##
       ## Send a Slack notifcation if the workflow has failed.

--- a/orchestration/templates/cron-workflow.yaml
+++ b/orchestration/templates/cron-workflow.yaml
@@ -32,8 +32,12 @@ spec:
                     value: URL
                   - name: dataset-id
                     value: FOO
-                  - name: dataset-name
+                  - name: jade-dataset-name
                     value: FOO
+                  - name: jade-data-project
+                    value: FOO
+                  - name: jade-profile-id
+                    value: PROFILEFOO
                   - name: archive-path
                     value: weekly_release/ClinVarVariationRelease_00-latest_weekly.xml.gz
                   - name: gcs-prefix

--- a/orchestration/templates/cron-workflow.yaml
+++ b/orchestration/templates/cron-workflow.yaml
@@ -28,6 +28,8 @@ spec:
                 template: main
               arguments:
                 parameters:
+                  - name: dataset-id
+                    value: FOO
                   - name: archive-path
                     value: weekly_release/ClinVarVariationRelease_00-latest_weekly.xml.gz
                   - name: gcs-prefix

--- a/orchestration/templates/date-absent.yaml
+++ b/orchestration/templates/date-absent.yaml
@@ -13,6 +13,10 @@ spec:
     - name: main
       inputs:
         parameters:
+          - name: jade-data-project
+          {{- $jadeDataProject := "{{inputs.parameters.jade-data-project}}" }}
+          - name: jade-dataset-name
+          {{- $jadeDatasetName := "{{inputs.parameters.jade-dataset-name}}" }}
           - name: table-name
           {{- $tableName := "{{inputs.parameters.table-name}}" }}
           - name: release-date
@@ -74,9 +78,9 @@ spec:
           - name: DEST_DATASET_NAME
             value: {{ $destDatasetName | quote }}
           - name: REPO_DATA_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: {{ $jadeDataProject | quote }}
           - name: REPO_DATASET_NAME
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $jadeDatasetName | quote }}
           - name: RELEASE_DATE
             value: {{ $releaseDate | quote }}
           - name: VERSION_COL_NAME

--- a/orchestration/templates/date-present.yaml
+++ b/orchestration/templates/date-present.yaml
@@ -13,6 +13,10 @@ spec:
     - name: main
       inputs:
         parameters:
+          - name: jade-dataset-name
+          {{- $jadeDatasetName := "{{inputs.parameters.jade-dataset-name}}" }}
+          - name: jade-data-project
+          {{- $jadeDataProject := "{{inputs.parameters.jade-data-project}}" }}
           - name: table-name
           {{- $tableName := "{{inputs.parameters.table-name}}" }}
           - name: gcs-prefix
@@ -158,9 +162,9 @@ spec:
           - name: DEST_DATASET_NAME
             value: {{ $destDatasetName | quote }}
           - name: REPO_DATA_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: {{ $jadeDataProject | quote }}
           - name: REPO_DATASET_NAME
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $jadeDatasetName | quote }}
           - name: RELEASE_DATE
             value: {{ $releaseDate | quote }}
           - name: PREV_DATE
@@ -201,9 +205,9 @@ spec:
           - name: DEST_DATASET_NAME
             value: {{ $destDatasetName | quote }}
           - name: REPO_DATA_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: {{ $jadeDataProject | quote }}
           - name: REPO_DATASET_NAME
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $jadeDatasetName | quote }}
           - name: RELEASE_DATE
             value: {{ $releaseDate | quote }}
           - name: PREV_DATE
@@ -244,9 +248,9 @@ spec:
           - name: DEST_DATASET_NAME
             value: {{ $destDatasetName | quote }}
           - name: REPO_DATA_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: {{ $jadeDataProject | quote }}
           - name: REPO_DATASET_NAME
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $jadeDatasetName | quote }}
           - name: RELEASE_DATE
             value: {{ $releaseDate | quote }}
           - name: PREV_DATE
@@ -306,9 +310,9 @@ spec:
         command: [bash]
         env:
           - name: JADE_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: {{ $jadeDataProject | quote }}
           - name: JADE_DATASET
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $jadeDatasetName | quote }}
           - name: RELEASE_DATE
             value: {{ $releaseDate | quote }}
         source: |

--- a/orchestration/templates/dual-writer-cron-workflow.yaml
+++ b/orchestration/templates/dual-writer-cron-workflow.yaml
@@ -34,7 +34,7 @@ spec:
                   - name: jade-data-project
                     value: {{ .Values.altJade.dataProject }}
                   - name: jade-profile-id
-                    value: {{ .Values.altJade.profileIddd }}
+                    value: {{ .Values.altJade.profileId }}
                   - name: archive-path
                     value: weekly_release/ClinVarVariationRelease_00-latest_weekly.xml.gz
                   - name: gcs-prefix

--- a/orchestration/templates/dual-writer-cron-workflow.yaml
+++ b/orchestration/templates/dual-writer-cron-workflow.yaml
@@ -15,10 +15,7 @@ spec:
     onExit: {{ if .Values.notification.onlyOnFailure }}send-slack-notification-if-failed{{ else }}send-slack-notification{{ end }}
     templates:
       ##
-      ## Main entry-point to the regularly-run ClinVar ingest workflow.
-      ##
-      ## Delegates to a WorkflowTemplate for all of the business logic,
-      ## to support easily running manual ingests.
+      ## Copy of the base cron-workflow.yaml, subsituting in altJade connection info
       ##
       - name: main
         steps:

--- a/orchestration/templates/dual-writer-cron-workflow.yaml
+++ b/orchestration/templates/dual-writer-cron-workflow.yaml
@@ -79,5 +79,5 @@ spec:
           - -H
           - 'Authorization: Bearer $(OAUTH_TOKEN)'
           - -d
-          - '{"text": "Workflow $(WORKFLOW_ID) in env *$(WORKFLOW_ENV)* entered state: *$(WORKFLOW_STATE)*", "channel": "$(CHANNEL_ID)"}'
+          - '{"text": "(dual writer) Workflow $(WORKFLOW_ID) in env *$(WORKFLOW_ENV)* entered state: *$(WORKFLOW_STATE)*", "channel": "$(CHANNEL_ID)"}'
           - "https://slack.com/api/chat.postMessage"

--- a/orchestration/templates/dual-writer-cron-workflow.yaml
+++ b/orchestration/templates/dual-writer-cron-workflow.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
-  name: clinvar-ingest
+  name: dual-writer-clinvar-ingest
 spec:
   suspend: {{ not .Values.cron.enable }}
   schedule: {{ .Values.cron.schedule | quote }}
@@ -29,15 +29,15 @@ spec:
               arguments:
                 parameters:
                   - name: data-repo-url
-                    value: {{ .Values.jade.url }}
+                    value: {{ .Values.altJade.url }}
                   - name: dataset-id
-                    value: {{ .Values.jade.datasetId }}
+                    value: {{ .Values.altJade.datasetId }}
                   - name: jade-dataset-name
-                    value: {{ .Values.jade.datasetName }}
+                    value: {{ .Values.altJade.datasetName }}
                   - name: jade-data-project
-                    value: {{ .Values.jade.dataProject }}
+                    value: {{ .Values.altJade.dataProject }}
                   - name: jade-profile-id
-                    value: {{ .Values.jade.profileIddd }}
+                    value: {{ .Values.altJade.profileIddd }}
                   - name: archive-path
                     value: weekly_release/ClinVarVariationRelease_00-latest_weekly.xml.gz
                   - name: gcs-prefix
@@ -60,7 +60,7 @@ spec:
           image: curlimages/curl:7.70.0
           env:
             - name: CHANNEL_ID
-              value: {{ .Values.notification.channelId }}
+              value: {{ .Values.notification.altChannelId }}
             - name: WORKFLOW_ID
               value: '{{ "{{workflow.name}}" }}'
             - name: WORKFLOW_STATE

--- a/orchestration/templates/dual-writer-cron-workflow.yaml
+++ b/orchestration/templates/dual-writer-cron-workflow.yaml
@@ -42,6 +42,8 @@ spec:
                     value: weekly_release/ClinVarVariationRelease_00-latest_weekly.xml.gz
                   - name: gcs-prefix
                     value: {{ include "argo.timestamp" . | quote }}
+                  - name: should-export-diff
+                    value: false
 
       ##
       ## Send a Slack notifcation if the workflow has failed.

--- a/orchestration/templates/export-diff.yaml
+++ b/orchestration/templates/export-diff.yaml
@@ -15,6 +15,10 @@ spec:
     - name: main
       inputs:
         parameters:
+          - name: jade-data-project
+          {{- $jadeDataProject := "{{inputs.parameters.jade-data-project}}" }}
+          - name: jade-dataset-name
+          {{- $jadeDatasetName := "{{inputs.parameters.jade-dataset-name}}" }}
           - name: release-date
           {{- $releaseDate := "{{inputs.parameters.release-date}}" }}
           - name: dataset-name
@@ -91,6 +95,10 @@ spec:
                   value: {{ $gcsPrefix | quote }}
                 - name: dataset-name
                   value: {{ $datasetName | quote }}
+                - name: jade-dataset-name
+                  value: {{ $jadeDatasetName | quote }}
+                - name: jade-data-project
+                  value: {{ $jadeDataProject | quote }}
 
           ## Processes to run when the preceding date is present
           - name: date-present
@@ -122,6 +130,10 @@ spec:
               - variation_archive
             arguments:
               parameters:
+                - name: jade-dataset-name
+                  value: {{ $jadeDatasetName | quote }}
+                - name: jade-data-project
+                  value: {{ $jadeDataProject | quote }}
                 - name: table-name
                   value: {{ "{{item}}" | quote }}
                 - name: gcs-prefix
@@ -158,9 +170,9 @@ spec:
         command: [bash]
         env:
           - name: JADE_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: {{ $jadeDataProject | quote }}
           - name: JADE_DATASET
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $jadeDatasetName | quote }}
           - name: RELEASE_DATE
             value: {{ $releaseDate | quote }}
         source: |
@@ -194,8 +206,8 @@ spec:
           - name: PROJECT
             value: {{ .Values.staging.bigquery.project }}
           - name: JADE_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: {{ $jadeDataProject | quote }}
           - name: JADE_DATASET
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $jadeDatasetName | quote }}
         source: |
         {{- include "argo.render-lines" (.Files.Lines "scripts/check-if-processed-today.sh") | indent 10 }}

--- a/orchestration/templates/ingest-clinvar-release-e2e.yaml
+++ b/orchestration/templates/ingest-clinvar-release-e2e.yaml
@@ -15,6 +15,8 @@ spec:
     - name: main
       inputs:
         parameters:
+          - name: should-export-diff
+          {{- $shouldExportDiff := "{{inputs.parameters.should-export-diff}}" }}
           - name: jade-profile-id
           {{- $jadeProfileId := "{{inputs.parameters.jade-profile-id}}" }}
           - name: data-repo-url
@@ -73,10 +75,9 @@ spec:
                 - name: gcs-prefix
                   value: {{ $gcsPrefix | quote }}
             {{- $datasetName := "{{tasks.process-archive.outputs.parameters.dataset-name}}" }}
-          {{- $shouldExportDiff := printf "%t" .Values.steps.exportDiff.enabled }}
 
           - name: export-diff
-            when: {{ printf "%s == true" $shouldExportDiff }}
+            when: {{ printf "%s == true" $shouldExportDiff | quote }}
             dependencies: [process-archive]
             templateRef:
               name: export-diff

--- a/orchestration/templates/ingest-clinvar-release-e2e.yaml
+++ b/orchestration/templates/ingest-clinvar-release-e2e.yaml
@@ -19,6 +19,8 @@ spec:
           {{- $dataRepoUrl := "{{inputs.parameters.data-repo-url}}" }}
           - name: dataset-id
           {{- $datasetId := "{{inputs.parameters.dataset-id}}" }}
+          - name: dataset-name
+          {{- $datasetName := "{{inputs.parameters.dataset-name}}" }}
           - name: archive-path
           {{- $archivePath := "{{inputs.parameters.archive-path}}" }}
           - name: gcs-prefix
@@ -31,8 +33,12 @@ spec:
               template: main
             arguments:
               parameters:
+                - name: data-repo-url
+                  value: {{ $dataRepoUrl | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
+                - name: dataset-name
+                  value: {{ $datasetName | quote }}
                 - name: archive-path
                   value: {{ $archivePath | quote }}
                 - name: gcs-prefix
@@ -46,8 +52,12 @@ spec:
               template: main
             arguments:
               parameters:
+                - name: data-repo-url
+                  value: {{ $dataRepoUrl | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
+                - name: dataset-name
+                  value: {{ $datasetName | quote }}
                 - name: release-date
                   value: {{ $releaseDate | quote }}
                 - name: gcs-prefix

--- a/orchestration/templates/ingest-clinvar-release-e2e.yaml
+++ b/orchestration/templates/ingest-clinvar-release-e2e.yaml
@@ -29,6 +29,8 @@ spec:
               template: main
             arguments:
               parameters:
+                - name: dataset-id
+                  value: {{ $datasetId | quote }}
                 - name: archive-path
                   value: {{ $archivePath | quote }}
                 - name: gcs-prefix

--- a/orchestration/templates/ingest-clinvar-release-e2e.yaml
+++ b/orchestration/templates/ingest-clinvar-release-e2e.yaml
@@ -15,6 +15,8 @@ spec:
     - name: main
       inputs:
         parameters:
+          - name: data-repo-url
+          {{- $dataRepoUrl := "{{inputs.parameters.data-repo-url}}" }}
           - name: dataset-id
           {{- $datasetId := "{{inputs.parameters.dataset-id}}" }}
           - name: archive-path

--- a/orchestration/templates/ingest-clinvar-release-e2e.yaml
+++ b/orchestration/templates/ingest-clinvar-release-e2e.yaml
@@ -39,6 +39,8 @@ spec:
               template: main
             arguments:
               parameters:
+                - name: jade-profile-id
+                  value: {{ $jadeProfileId | quote }}
                 - name: jade-data-project
                   value: {{ $jadeDataProject | quote }}
                 - name: data-repo-url

--- a/orchestration/templates/ingest-clinvar-release-e2e.yaml
+++ b/orchestration/templates/ingest-clinvar-release-e2e.yaml
@@ -15,6 +15,8 @@ spec:
     - name: main
       inputs:
         parameters:
+          - name: dataset-id
+          {{- $datasetId := "{{inputs.parameters.dataset-id}}" }}
           - name: archive-path
           {{- $archivePath := "{{inputs.parameters.archive-path}}" }}
           - name: gcs-prefix

--- a/orchestration/templates/ingest-clinvar-release-e2e.yaml
+++ b/orchestration/templates/ingest-clinvar-release-e2e.yaml
@@ -44,6 +44,8 @@ spec:
               template: main
             arguments:
               parameters:
+                - name: dataset-id
+                  value: {{ $datasetId | quote }}
                 - name: release-date
                   value: {{ $releaseDate | quote }}
                 - name: gcs-prefix

--- a/orchestration/templates/ingest-clinvar-release-e2e.yaml
+++ b/orchestration/templates/ingest-clinvar-release-e2e.yaml
@@ -15,12 +15,16 @@ spec:
     - name: main
       inputs:
         parameters:
+          - name: jade-profile-id
+          {{- $jadeProfileId := "{{inputs.parameters.jade-profile-id}}" }}
           - name: data-repo-url
           {{- $dataRepoUrl := "{{inputs.parameters.data-repo-url}}" }}
           - name: dataset-id
           {{- $datasetId := "{{inputs.parameters.dataset-id}}" }}
-          - name: dataset-name
-          {{- $datasetName := "{{inputs.parameters.dataset-name}}" }}
+          - name: jade-dataset-name
+          {{- $jadeDatasetName := "{{inputs.parameters.jade-dataset-name}}" }}
+          - name: jade-data-project
+          {{- $jadeDataProject := "{{inputs.parameters.jade-data-project}}" }}
           - name: archive-path
           {{- $archivePath := "{{inputs.parameters.archive-path}}" }}
           - name: gcs-prefix
@@ -33,12 +37,14 @@ spec:
               template: main
             arguments:
               parameters:
+                - name: jade-data-project
+                  value: {{ $jadeDataProject | quote }}
                 - name: data-repo-url
                   value: {{ $dataRepoUrl | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
                 - name: dataset-name
-                  value: {{ $datasetName | quote }}
+                  value: {{ $jadeDatasetName | quote }}
                 - name: archive-path
                   value: {{ $archivePath | quote }}
                 - name: gcs-prefix
@@ -52,12 +58,16 @@ spec:
               template: main
             arguments:
               parameters:
+                - name: jade-profile-id
+                  value: {{ $jadeProfileId | quote }}
                 - name: data-repo-url
                   value: {{ $dataRepoUrl | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
                 - name: dataset-name
-                  value: {{ $datasetName | quote }}
+                  value: {{ $jadeDatasetName | quote }}
+                - name: jade-data-project
+                  value: {{ $jadeDataProject | quote }}
                 - name: release-date
                   value: {{ $releaseDate | quote }}
                 - name: gcs-prefix
@@ -73,6 +83,12 @@ spec:
               template: main
             arguments:
               parameters:
+                - name: jade-profile-id
+                  value: {{ $jadeProfileId | quote }}
+                - name: jade-data-project
+                  value: {{ $jadeDataProject | quote }}
+                - name: jade-dataset-name
+                  value: {{ $jadeDatasetName | quote }}
                 - name: release-date
                   value: {{ $releaseDate | quote }}
                 - name: dataset-name

--- a/orchestration/templates/ingest-xml-archive.yaml
+++ b/orchestration/templates/ingest-xml-archive.yaml
@@ -19,6 +19,8 @@ spec:
     - name: main
       inputs:
         parameters:
+          - name: dataset-id
+          {{- $datasetId := "{{inputs.parameters.dataset-id}}" }}
           - name: archive-path
           {{- $archivePath := "{{inputs.parameters.archive-path}}" }}
           - name: gcs-prefix

--- a/orchestration/templates/ingest-xml-archive.yaml
+++ b/orchestration/templates/ingest-xml-archive.yaml
@@ -200,7 +200,7 @@ spec:
                 - name: url
                   value: {{ .url }}
                 - name: dataset-id
-                  value: {{ .datasetId }}
+                  value: {{ $datasetId | quote }}
                 - name: profile-id
                   value: {{ .profileId }}
                 - name: sa-secret

--- a/orchestration/templates/ingest-xml-archive.yaml
+++ b/orchestration/templates/ingest-xml-archive.yaml
@@ -261,7 +261,7 @@ spec:
                 - name: url
                   value: {{ .url }}
                 - name: dataset-id
-                  value: {{ .datasetId }}
+                  value: {{ $datasetId | quote }}
                 - name: profile-id
                   value: {{ .profileId }}
                 - name: timeout

--- a/orchestration/templates/ingest-xml-archive.yaml
+++ b/orchestration/templates/ingest-xml-archive.yaml
@@ -19,6 +19,10 @@ spec:
     - name: main
       inputs:
         parameters:
+          - name: jade-profile-id
+          {{- $jadeProfileId := "{{inputs.parameters.jade-profile-id}}" }}
+          - name: jade-data-project
+          {{- $jadeDataProject := "{{inputs.parameters.jade-data-project}}" }}
           - name: data-repo-url
           {{- $dataRepoUrl := "{{inputs.parameters.data-repo-url}}" }}
           - name: dataset-id
@@ -163,7 +167,7 @@ spec:
           - name: PROJECT
             value: {{ .Values.staging.bigquery.project }}
           - name: JADE_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: {{ $jadeDataProject | quote }}
           - name: JADE_DATASET
             value: {{ printf "datarepo_%s" $datasetName | quote }}
           - name: RELEASE_DATE
@@ -200,18 +204,16 @@ spec:
               parameters:
                 - name: virtual-path
                   value: {{ $targetPath | quote }}
-                {{- with .Values.jade }}
                 - name: url
                   value: {{ $dataRepoUrl | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
                 - name: profile-id
-                  value: {{ .profileId }}
+                  value: {{ $jadeProfileId | quote }}
                 - name: sa-secret
-                  value: {{ .accessKey.secretName }}
+                  value: {{ .Values.jade.accessKey.secretName }}
                 - name: sa-secret-key
-                  value: {{ .accessKey.secretKey }}
-                {{- end }}
+                  value: {{ .Values.jade.accessKey.secretKey }}
             {{- $existingFileId := "{{tasks.check-for-existing-file.outputs.result}}" }}
             {{- $shouldIngestFile := printf "'%s' == null" $existingFileId }}
 
@@ -261,20 +263,18 @@ spec:
             arguments:
               parameters:
                 {{- $gcsFilePath := printf "%s/xml/%s" $gcsPrefix (include "clinvar.raw-archive-name" .) | quote }}
-                {{- with .Values.jade }}
                 - name: url
                   value: {{ $dataRepoUrl | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
                 - name: profile-id
-                  value: {{ .profileId }}
+                  value: {{ $jadeProfileId | quote }}
                 - name: timeout
-                  value: {{ .pollTimeout }}
+                  value: {{ .Values.jade.pollTimeout }}
                 - name: sa-secret
-                  value: {{ .accessKey.secretName }}
+                  value: {{ .Values.jade.accessKey.secretName }}
                 - name: sa-secret-key
-                  value: {{ .accessKey.secretKey }}
-                {{- end }}
+                  value: {{ .Values.jade.accessKey.secretKey }}
                 - name: target-path
                   value: {{ $targetPath | quote }}
                 - name: gcs-bucket
@@ -341,18 +341,16 @@ spec:
                   value: {{ .Values.staging.gcsBucket }}
                 - name: gcs-prefix
                   value: {{ $jsonPrefix | quote }}
-                {{- with .Values.jade }}
                 - name: url
                   value: {{ $dataRepoUrl | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
                 - name: timeout
-                  value: {{ .pollTimeout }}
+                  value: {{ .Values.jade.pollTimeout }}
                 - name: sa-secret
-                  value: {{ .accessKey.secretName }}
+                  value: {{ .Values.jade.accessKey.secretName }}
                 - name: sa-secret-key
-                  value: {{ .accessKey.secretKey }}
-                {{- end }}
+                  value: {{ .Values.jade.accessKey.secretKey }}
 
     ##
     ## Stage a JSON object in GCS containing data for a row in the xml_archive table.

--- a/orchestration/templates/ingest-xml-archive.yaml
+++ b/orchestration/templates/ingest-xml-archive.yaml
@@ -19,8 +19,12 @@ spec:
     - name: main
       inputs:
         parameters:
+          - name: data-repo-url
+          {{- $dataRepoUrl := "{{inputs.parameters.data-repo-url}}" }}
           - name: dataset-id
           {{- $datasetId := "{{inputs.parameters.dataset-id}}" }}
+          - name: dataset-name
+          {{- $datasetName := "{{inputs.parameters.dataset-name}}" }}
           - name: archive-path
           {{- $archivePath := "{{inputs.parameters.archive-path}}" }}
           - name: gcs-prefix
@@ -161,7 +165,7 @@ spec:
           - name: JADE_PROJECT
             value: {{ .Values.jade.dataProject }}
           - name: JADE_DATASET
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $datasetName | quote }}
           - name: RELEASE_DATE
             value: {{ $releaseDate | quote }}
           - name: PROPERTY
@@ -198,7 +202,7 @@ spec:
                   value: {{ $targetPath | quote }}
                 {{- with .Values.jade }}
                 - name: url
-                  value: {{ .url }}
+                  value: {{ $dataRepoUrl | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
                 - name: profile-id
@@ -259,7 +263,7 @@ spec:
                 {{- $gcsFilePath := printf "%s/xml/%s" $gcsPrefix (include "clinvar.raw-archive-name" .) | quote }}
                 {{- with .Values.jade }}
                 - name: url
-                  value: {{ .url }}
+                  value: {{ $dataRepoUrl | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
                 - name: profile-id
@@ -339,7 +343,7 @@ spec:
                   value: {{ $jsonPrefix | quote }}
                 {{- with .Values.jade }}
                 - name: url
-                  value: {{ .url }}
+                  value: {{ $dataRepoUrl | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
                 - name: timeout

--- a/orchestration/templates/ingest-xml-archive.yaml
+++ b/orchestration/templates/ingest-xml-archive.yaml
@@ -167,9 +167,9 @@ spec:
           - name: PROJECT
             value: {{ .Values.staging.bigquery.project }}
           - name: JADE_PROJECT
-            value: {{ $jadeDataProject | quote }}
+            value: {{ $jadeDataProject }}
           - name: JADE_DATASET
-            value: {{ printf "datarepo_%s" $datasetName | quote }}
+            value: {{ printf "datarepo_%s" $datasetName }}
           - name: RELEASE_DATE
             value: {{ $releaseDate | quote }}
           - name: PROPERTY

--- a/orchestration/templates/ingest-xml-archive.yaml
+++ b/orchestration/templates/ingest-xml-archive.yaml
@@ -156,7 +156,8 @@ spec:
     ##
     ## Check if a row exists in the xml_archive table for a given release date.
     ##
-    {{- $fullDatasetName := printf "datarepo_%s" $datasetName | quote }}
+    {{- $fullDatasetName := printf "datarepo_%s" $datasetName }}
+
     - name: check-for-existing-release
       inputs:
         parameters:

--- a/orchestration/templates/ingest-xml-archive.yaml
+++ b/orchestration/templates/ingest-xml-archive.yaml
@@ -341,7 +341,7 @@ spec:
                 - name: url
                   value: {{ .url }}
                 - name: dataset-id
-                  value: {{ .datasetId }}
+                  value: {{ $datasetId | quote }}
                 - name: timeout
                   value: {{ .pollTimeout }}
                 - name: sa-secret

--- a/orchestration/templates/ingest-xml-archive.yaml
+++ b/orchestration/templates/ingest-xml-archive.yaml
@@ -156,6 +156,7 @@ spec:
     ##
     ## Check if a row exists in the xml_archive table for a given release date.
     ##
+    {{- $fullDatasetName := printf "datarepo_%s" $datasetName | quote }}
     - name: check-for-existing-release
       inputs:
         parameters:
@@ -167,9 +168,9 @@ spec:
           - name: PROJECT
             value: {{ .Values.staging.bigquery.project }}
           - name: JADE_PROJECT
-            value: {{ $jadeDataProject }}
+            value: {{ $jadeDataProject | quote }}
           - name: JADE_DATASET
-            value: {{ printf "datarepo_%s" $datasetName }}
+            value: {{ $fullDatasetName | quote }}
           - name: RELEASE_DATE
             value: {{ $releaseDate | quote }}
           - name: PROPERTY

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -18,12 +18,16 @@ spec:
     - name: main
       inputs:
         parameters:
+          - name: jade-profile-id
+          {{- $jadeProfileId := "{{inputs.parameters.jade-profile-id}}" }}
           - name: data-repo-url
           {{- $dataRepoUrl := "{{inputs.parameters.data-repo-url}}" }}
           - name: dataset-id
           {{- $datasetId := "{{inputs.parameters.dataset-id}}" }}
           - name: jade-dataset-name
           {{- $jadeDatasetName := "{{inputs.parameters.jade-dataset-name}}" }}
+          - name: jade-data-project
+          {{- $jadeDataProject := "{{inputs.parameters.jade-data-project}}" }}
           - name: release-date
           {{- $releaseDate := "{{inputs.parameters.release-date}}" }}
           - name: gcs-prefix
@@ -59,6 +63,8 @@ spec:
               template: main
             arguments:
               parameters:
+                - name: jade-data-project
+                  value: {{ $jadeDataProject | quote }}
                 - name: data-repo-url
                   value: {{ $dataRepoUrl | quote }}
                 - name: dataset-id
@@ -219,7 +225,7 @@ spec:
                 - name: staging-bq-dataset
                   value: {{ $datasetName | quote }}
                 - name: jade-bq-project
-                  value: {{ .Values.jade.dataProject }}
+                  value: {{ $jadeDataProject | quote }}
                 - name: jade-bq-dataset
                   value: {{ printf "datarepo_%s" $jadeDatasetName | quote }}
                 - name: upsert
@@ -247,18 +253,16 @@ spec:
                   value: {{ $oldIdsPrefix | quote }}
                 - name: gcs-bucket
                   value: {{ .Values.staging.gcsBucket }}
-                {{- with .Values.jade }}
                 - name: url
                   value: {{ $dataRepoUrl | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
                 - name: timeout
-                  value: {{ .pollTimeout }}
+                  value: {{ .Values.jade.pollTimeout }}
                 - name: sa-secret
-                  value: {{ .accessKey.secretName }}
+                  value: {{ .Values.jade.accessKey.secretName }}
                 - name: sa-secret-key
-                  value: {{ .accessKey.secretKey }}
-                {{- end }}
+                  value: {{ .Values.jade.accessKey.secretKey }}
 
           # Append rows with new data.
           - name: ingest-table
@@ -275,18 +279,16 @@ spec:
                   value: {{ .Values.staging.gcsBucket }}
                 - name: gcs-prefix
                   value: {{ $newRowsPrefix | quote }}
-                {{- with .Values.jade }}
                 - name: url
                   value: {{ $dataRepoUrl | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
                 - name: timeout
-                  value: {{ .pollTimeout }}
+                  value: {{ .Values.jade.pollTimeout }}
                 - name: sa-secret
-                  value: {{ .accessKey.secretName }}
+                  value: {{ .Values.jade.accessKey.secretName }}
                 - name: sa-secret-key
-                  value: {{ .accessKey.secretKey }}
-                {{- end }}
+                  value: {{ .Values.jade.accessKey.secretKey }}
 
     {{- if $versionIsPinned }}
     # check if the latest snapshot release date corresponds to the latest xml release date
@@ -305,7 +307,7 @@ spec:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: {{ printf "/secret/%s" .Values.jade.accessKey.secretKey }}
           - name: REPO_DATA_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: {{ $jadeDataProject | quote }}
           - name: REPO_DATASET_NAME
             value: {{ printf "datarepo_%s" $jadeDatasetName | quote }}
           - name: REPO_HOST
@@ -370,16 +372,14 @@ spec:
               parameters:
                 - name: job-id
                   value: {{ $jobId | quote }}
-                {{- with .Values.jade }}
                 - name: api-url
                   value: {{ $dataRepoUrl | quote }}
                 - name: timeout
-                  value: {{ .pollTimeout }}
+                  value: {{ .Values.jade.pollTimeout }}
                 - name: sa-secret
-                  value: {{ .accessKey.secretName }}
+                  value: {{ .Values.jade.accessKey.secretName }}
                 - name: sa-secret-key
-                  value: {{ .accessKey.secretKey }}
-                {{- end }}
+                  value: {{ .Values.jade.accessKey.secretKey }}
 
     ##
     ## Count the number of rows in the processing_history table with a given release-date/version pair.
@@ -396,7 +396,7 @@ spec:
           - name: PROJECT
             value: {{ .Values.staging.bigquery.project }}
           - name: JADE_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: {{ $jadeDataProject | quote }}
           - name: JADE_DATASET
             value: {{ printf "datarepo_%s" $jadeDatasetName | quote }}
           - name: RELEASE_DATE
@@ -438,10 +438,9 @@ spec:
           - name: release-date
             {{- $releaseDate := "{{inputs.parameters.release-date}}" }}
       volumes:
-        {{- with .Values.jade }}
         - name: sa-secret-volume
           secret:
-            secretName: {{ .accessKey.secretName }}
+            secretName: {{ .Values.jade.accessKey.secretName }}
       script:
         image: us.gcr.io/broad-dsp-gcr-public/monster-auth-req-py:1.0.1
         volumeMounts:
@@ -453,12 +452,11 @@ spec:
           - name: DATASET_NAME
             value: {{ $jadeDatasetName | quote }}
           - name: PROFILE_ID
-            value: {{ .profileId }}
+            value: {{ $jadeProfileId | quote }}
           - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: {{ printf "/secret/%s" .accessKey.secretKey }}
+            value: {{ printf "/secret/%s" .Values.jade.accessKey.secretKey }}
           - name: ASSET_NAME
-            value: {{ .snapshotAssetName }}
-        {{- end }}
+            value: {{ .Values.jade.snapshotAssetName }}
           - name: RELEASE_DATE
             value: {{ $releaseDate | quote }}
           - name: PIPELINE_VERSION

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -18,8 +18,12 @@ spec:
     - name: main
       inputs:
         parameters:
+          - name: data-repo-url
+          {{- $dataRepoUrl := "{{inputs.parameters.data-repo-url}}" }}
           - name: dataset-id
           {{- $datasetId := "{{inputs.parameters.dataset-id}}" }}
+          - name: jade-dataset-name
+          {{- $jadeDatasetName := "{{inputs.parameters.jade-dataset-name}}" }}
           - name: release-date
           {{- $releaseDate := "{{inputs.parameters.release-date}}" }}
           - name: gcs-prefix
@@ -55,6 +59,8 @@ spec:
               template: main
             arguments:
               parameters:
+                - name: data-repo-url
+                  value: {{ $dataRepoUrl | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
                 - name: release-date
@@ -215,7 +221,7 @@ spec:
                 - name: jade-bq-project
                   value: {{ .Values.jade.dataProject }}
                 - name: jade-bq-dataset
-                  value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+                  value: {{ printf "datarepo_%s" $jadeDatasetName | quote }}
                 - name: upsert
                   value: 'false'
                 - name: diff-full-history
@@ -243,7 +249,7 @@ spec:
                   value: {{ .Values.staging.gcsBucket }}
                 {{- with .Values.jade }}
                 - name: url
-                  value: {{ .url }}
+                  value: {{ $dataRepoUrl | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
                 - name: timeout
@@ -271,7 +277,7 @@ spec:
                   value: {{ $newRowsPrefix | quote }}
                 {{- with .Values.jade }}
                 - name: url
-                  value: {{ .url }}
+                  value: {{ $dataRepoUrl | quote }}
                 - name: dataset-id
                   value: {{ $datasetId | quote }}
                 - name: timeout
@@ -301,9 +307,9 @@ spec:
           - name: REPO_DATA_PROJECT
             value: {{ .Values.jade.dataProject }}
           - name: REPO_DATASET_NAME
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $jadeDatasetName | quote }}
           - name: REPO_HOST
-            value: {{ .Values.jade.url }}
+            value: {{ $dataRepoUrl | quote }}
           - name: REPO_DATASET_ID
             value: {{ $datasetId | quote }}
         command: ["python", "-c", "import check; check.run()"]
@@ -366,7 +372,7 @@ spec:
                   value: {{ $jobId | quote }}
                 {{- with .Values.jade }}
                 - name: api-url
-                  value: {{ .url }}
+                  value: {{ $dataRepoUrl | quote }}
                 - name: timeout
                   value: {{ .pollTimeout }}
                 - name: sa-secret
@@ -392,7 +398,7 @@ spec:
           - name: JADE_PROJECT
             value: {{ .Values.jade.dataProject }}
           - name: JADE_DATASET
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $jadeDatasetName | quote }}
           - name: RELEASE_DATE
             value: {{ $releaseDate | quote }}
           - name: VERSION
@@ -443,9 +449,9 @@ spec:
             mountPath: /secret
         env:
           - name: API_URL
-            value: {{ .url }}
+            value: {{ $dataRepoUrl | quote }}
           - name: DATASET_NAME
-            value: {{ .datasetName }}
+            value: {{ $jadeDatasetName | quote }}
           - name: PROFILE_ID
             value: {{ .profileId }}
           - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -305,7 +305,7 @@ spec:
           - name: REPO_HOST
             value: {{ .Values.jade.url }}
           - name: REPO_DATASET_ID
-            value: {{ .Values.jade.datasetId }}
+            value: {{ $datasetId | quote }}
         command: ["python", "-c", "import check; check.run()"]
 
     ##

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -55,6 +55,8 @@ spec:
               template: main
             arguments:
               parameters:
+                - name: dataset-id
+                  value: {{ $datasetId | quote }}
                 - name: release-date
                   value: {{ $releaseDate | quote }}
                 - name: gcs-prefix

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -18,6 +18,8 @@ spec:
     - name: main
       inputs:
         parameters:
+          - name: dataset-id
+          {{- $datasetId := "{{inputs.parameters.dataset-id}}" }}
           - name: release-date
           {{- $releaseDate := "{{inputs.parameters.release-date}}" }}
           - name: gcs-prefix

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -245,7 +245,7 @@ spec:
                 - name: url
                   value: {{ .url }}
                 - name: dataset-id
-                  value: {{ .datasetId }}
+                  value: {{ $datasetId | quote }}
                 - name: timeout
                   value: {{ .pollTimeout }}
                 - name: sa-secret

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -273,7 +273,7 @@ spec:
                 - name: url
                   value: {{ .url }}
                 - name: dataset-id
-                  value: {{ .datasetId }}
+                  value: {{ $datasetId | quote }}
                 - name: timeout
                   value: {{ .pollTimeout }}
                 - name: sa-secret

--- a/orchestration/templates/process-xml-release.yaml
+++ b/orchestration/templates/process-xml-release.yaml
@@ -12,6 +12,8 @@ spec:
     - name: main
       inputs:
         parameters:
+          - name: dataset-id
+          {{- $datasetId := "{{inputs.parameters.dataset-id}}" }}
           - name: release-date
           {{- $releaseDate := "{{inputs.parameters.release-date}}" }}
           - name: gcs-prefix

--- a/orchestration/templates/process-xml-release.yaml
+++ b/orchestration/templates/process-xml-release.yaml
@@ -12,8 +12,12 @@ spec:
     - name: main
       inputs:
         parameters:
+          - name: data-repo-url
+          {{- $dataRepoUrl := "{{inputs.parameters.data-repo-url}}" }}
           - name: dataset-id
           {{- $datasetId := "{{inputs.parameters.dataset-id}}" }}
+          - name: dataset-name
+          {{- $datasetName := "{{inputs.parameters.dataset-name}}" }}
           - name: release-date
           {{- $releaseDate := "{{inputs.parameters.release-date}}" }}
           - name: gcs-prefix
@@ -180,7 +184,7 @@ spec:
           - name: JADE_PROJECT
             value: {{ .Values.jade.dataProject }}
           - name: JADE_DATASET
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $datasetName | quote }}
           - name: PROPERTY
             value: archive_path
         command: [bash]
@@ -208,7 +212,7 @@ spec:
             mountPath: /secret
         env:
           - name: API_URL
-            value: {{ .Values.jade.url }}
+            value: {{ $dataRepoUrl | quote }}
           - name: DATASET_ID
             value: {{ $datasetId | quote }}
           - name: FILE_ID

--- a/orchestration/templates/process-xml-release.yaml
+++ b/orchestration/templates/process-xml-release.yaml
@@ -12,6 +12,8 @@ spec:
     - name: main
       inputs:
         parameters:
+          - name: jade-data-project
+          {{- $jadeDataProject := "{{inputs.parameters.jade-data-project}}" }}
           - name: data-repo-url
           {{- $dataRepoUrl := "{{inputs.parameters.data-repo-url}}" }}
           - name: dataset-id
@@ -182,7 +184,7 @@ spec:
           - name: PROJECT
             value: {{ .Values.staging.bigquery.project }}
           - name: JADE_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: {{ $jadeDataProject | quote }}
           - name: JADE_DATASET
             value: {{ printf "datarepo_%s" $datasetName | quote }}
           - name: PROPERTY

--- a/orchestration/templates/process-xml-release.yaml
+++ b/orchestration/templates/process-xml-release.yaml
@@ -210,7 +210,7 @@ spec:
           - name: API_URL
             value: {{ .Values.jade.url }}
           - name: DATASET_ID
-            value: {{ .Values.jade.datasetId }}
+            value: {{ $datasetId | quote }}
           - name: FILE_ID
             value: {{ $archiveId | quote }}
           - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/orchestration/values.schema.json
+++ b/orchestration/values.schema.json
@@ -150,17 +150,6 @@
       },
       "required": ["gcsBucket", "kafka"]
     },
-    "steps": {
-      "type": "object",
-      "properties": {
-        "exportDiffs": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type":  "boolean" }
-          }
-        }
-      }
-    }
   },
   "required": ["parallelism", "staging", "jade", "altJade","serviceAccount",
                "volumes", "cron", "dataflow", "notification", "clingen"]

--- a/orchestration/values.schema.json
+++ b/orchestration/values.schema.json
@@ -21,6 +21,28 @@
       },
       "required": ["gcsBucket", "bigquery"]
     },
+    "altJade": {
+      "type": "object",
+      "properties": {
+        "url": { "type": "string" },
+        "datasetId": { "type": "string" },
+        "datasetName": { "type": "string" },
+        "profileId": { "type": "string" },
+        "pollTimeout": { "type": "integer" },
+        "dataProject": { "type": "string" },
+        "accessKey": {
+          "type": "object",
+          "properties": {
+            "secretName": { "type": "string" },
+            "secretKey": { "type": "string" }
+          },
+          "required": ["secretName", "secretKey"]
+        },
+        "snapshotAssetName": { "type": "string" }
+      },
+      "required": ["url", "datasetId", "datasetName", "profileId", "pollTimeout",
+        "dataProject", "accessKey", "snapshotAssetName"]
+    },
     "jade": {
       "type": "object",
       "properties": {
@@ -99,6 +121,7 @@
     "notification": {
       "type": "object",
       "properties": {
+        "altChannelId": { "type":  "string" },
         "channelId": { "type":  "string" },
         "onlyOnFailure": { "type": "boolean" },
         "oauthToken": {
@@ -139,6 +162,6 @@
       }
     }
   },
-  "required": ["parallelism", "staging", "jade", "serviceAccount",
+  "required": ["parallelism", "staging", "jade", "altJade","serviceAccount",
                "volumes", "cron", "dataflow", "notification", "clingen"]
 }

--- a/orchestration/values.schema.json
+++ b/orchestration/values.schema.json
@@ -149,7 +149,7 @@
         }
       },
       "required": ["gcsBucket", "kafka"]
-    },
+    }
   },
   "required": ["parallelism", "staging", "jade", "altJade","serviceAccount",
                "volumes", "cron", "dataflow", "notification", "clingen"]

--- a/orchestration/values.yaml
+++ b/orchestration/values.yaml
@@ -15,6 +15,10 @@ dataflow:
     minWorkers: 4
     maxWorkers: 8
   useFlexRS: false
+altJade:
+  # 24 hours -> 86400 seconds
+  pollTimeout: 86400
+  snapshotAssetName: clinvar_release
 jade:
   # 24 hours -> 86400 seconds
   pollTimeout: 86400


### PR DESCRIPTION
The original approach for dual writing was going to be to create a new "clinvar-real-prod" deployment in monster-deploy. This has proven to not be workable.

The alternative approach implemented in this PR is to parameterize the Jade connection information at the top of the workflow and have that flow into all downstream templates. This PR adds a new "dual-writer" cron workflow that is a copy of the existing cron-workflow, but wiring in "alternate" jade connection values (i.e., real prod connection values).