### PR TITLE
Parameterize jade connection information (mk3)

### DIFF
--- a/orchestration/example-values/no-version.yaml
+++ b/orchestration/example-values/no-version.yaml
@@ -35,6 +35,3 @@ notification:
   oauthToken:
     secretName: aaaaa
     secretKey: bbbbb
-steps:
-  exportDiff:
-    enabled: true

--- a/orchestration/example-values/no-version.yaml
+++ b/orchestration/example-values/no-version.yaml
@@ -39,6 +39,7 @@ dataflow:
   subnetName: network
   workerAccount: runner@zoog
 notification:
+  altChannelId: othermonstertest
   channelId: monstertest
   onlyOnFailure: false
   oauthToken:

--- a/orchestration/example-values/no-version.yaml
+++ b/orchestration/example-values/no-version.yaml
@@ -14,6 +14,15 @@ jade:
   accessKey:
     secretName: dont-tell
     secretKey: its-a-secret
+altJade:
+  url: http://jade.repo
+  datasetId: a
+  datasetName: clinvar
+  profileId: b
+  dataProject: dataaaaa
+  accessKey:
+    secretName: dont-tell
+    secretKey: its-a-secret
 clingen:
   gcsBucket: buc
   kafka:

--- a/orchestration/example-values/pinned-version.yaml
+++ b/orchestration/example-values/pinned-version.yaml
@@ -15,6 +15,15 @@ jade:
   accessKey:
     secretName: dont-tell
     secretKey: its-a-secret
+altJade:
+  url: http://jade.repo
+  datasetId: a
+  datasetName: clinvar
+  profileId: b
+  dataProject: dataaaaa
+  accessKey:
+    secretName: dont-tell
+    secretKey: its-a-secret
 clingen:
   gcsBucket: buc
   kafka:

--- a/orchestration/example-values/pinned-version.yaml
+++ b/orchestration/example-values/pinned-version.yaml
@@ -43,6 +43,7 @@ argoTemplates:
   diffBQTable:
     schemaImageVersion: adsaasdf
 notification:
+  altChannelId: othermonstertest
   channelId: monstertest
   onlyOnFailure: true
   oauthToken:

--- a/orchestration/example-values/pinned-version.yaml
+++ b/orchestration/example-values/pinned-version.yaml
@@ -39,6 +39,3 @@ notification:
   oauthToken:
     secretName: aaaaa
     secretKey: bbbbb
-steps:
-  exportDiff:
-    enabled: true

--- a/orchestration/templates/cron-workflow.yaml
+++ b/orchestration/templates/cron-workflow.yaml
@@ -45,6 +45,8 @@ spec:
                     value: weekly_release/ClinVarVariationRelease_00-latest_weekly.xml.gz
                   - name: gcs-prefix
                     value: {{ include "argo.timestamp" . | quote }}
+                  - name: should-export-diff
+                    value: 'true'
 
       ##
       ## Send a Slack notifcation if the workflow has failed.

--- a/orchestration/templates/cron-workflow.yaml
+++ b/orchestration/templates/cron-workflow.yaml
@@ -12,15 +12,15 @@ spec:
     arguments:
       parameters:
         - name: jade-dataset-id
-          value: { { .Values.jade.datasetId } }
+          value: {{ .Values.jade.datasetId }}
         - name: jade-dataset-name
-          value: { { .Values.jade.datasetName } }
+          value: {{ .Values.jade.datasetName }}
         - name: jade-data-project
-          value: { { .Values.jade.dataProject } }
+          value: {{ .Values.jade.dataProject }}
         - name: jade-url
-          value: { { .Values.jade.url } }
+          value: {{ .Values.jade.url }}
         - name: jade-profile-id
-          value: { { .Values.jade.profileId } }
+          value: {{ .Values.jade.profileId }}
 
     serviceAccountName: {{ .Values.serviceAccount.k8sName }}
     podGC:

--- a/orchestration/templates/cron-workflow.yaml
+++ b/orchestration/templates/cron-workflow.yaml
@@ -9,6 +9,19 @@ spec:
   concurrencyPolicy: Forbid
   workflowSpec:
     entrypoint: main
+    arguments:
+      parameters:
+        - name: jade-dataset-id
+          value: { { .Values.jade.datasetId } }
+        - name: jade-dataset-name
+          value: { { .Values.jade.datasetName } }
+        - name: jade-data-project
+          value: { { .Values.jade.dataProject } }
+        - name: jade-url
+          value: { { .Values.jade.url } }
+        - name: jade-profile-id
+          value: { { .Values.jade.profileId } }
+
     serviceAccountName: {{ .Values.serviceAccount.k8sName }}
     podGC:
       strategy: OnWorkflowSuccess

--- a/orchestration/templates/date-absent.yaml
+++ b/orchestration/templates/date-absent.yaml
@@ -10,6 +10,8 @@ spec:
     ## Entrypoint for if there is not a previous date against which to diff.
     ##
     ##
+    {{- $jadeDatasetName := "{{workflow.parameters.jade-dataset-name}}" }}
+
     - name: main
       inputs:
         parameters:
@@ -74,9 +76,9 @@ spec:
           - name: DEST_DATASET_NAME
             value: {{ $destDatasetName | quote }}
           - name: REPO_DATA_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: '{{ "{{workflow.parameters.jade-data-project}}" }}'
           - name: REPO_DATASET_NAME
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $jadeDatasetName }}
           - name: RELEASE_DATE
             value: {{ $releaseDate | quote }}
           - name: VERSION_COL_NAME

--- a/orchestration/templates/date-present.yaml
+++ b/orchestration/templates/date-present.yaml
@@ -6,6 +6,8 @@ spec:
   entrypoint: main
   serviceAccountName: {{ .Values.serviceAccount.k8sName }}
   templates:
+    {{- $jadeDatasetName := "{{workflow.parameters.jade-dataset-name}}" }}
+
     ##
     ## Entrypoint for if there is a previous date against which to diff.
     ##
@@ -158,9 +160,9 @@ spec:
           - name: DEST_DATASET_NAME
             value: {{ $destDatasetName | quote }}
           - name: REPO_DATA_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: '{{ "{{workflow.parameters.jade-data-project}}" }}'
           - name: REPO_DATASET_NAME
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $jadeDatasetName }}
           - name: RELEASE_DATE
             value: {{ $releaseDate | quote }}
           - name: PREV_DATE
@@ -201,9 +203,9 @@ spec:
           - name: DEST_DATASET_NAME
             value: {{ $destDatasetName | quote }}
           - name: REPO_DATA_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: '{{ "{{workflow.parameters.jade-data-project}}" }}'
           - name: REPO_DATASET_NAME
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $jadeDatasetName }}
           - name: RELEASE_DATE
             value: {{ $releaseDate | quote }}
           - name: PREV_DATE
@@ -244,9 +246,9 @@ spec:
           - name: DEST_DATASET_NAME
             value: {{ $destDatasetName | quote }}
           - name: REPO_DATA_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: '{{ "{{workflow.parameters.jade-data-project}}" }}'
           - name: REPO_DATASET_NAME
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $jadeDatasetName }}
           - name: RELEASE_DATE
             value: {{ $releaseDate | quote }}
           - name: PREV_DATE
@@ -306,9 +308,9 @@ spec:
         command: [bash]
         env:
           - name: JADE_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: '{{ "{{workflow.parameters.jade-data-project}}" }}'
           - name: JADE_DATASET
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $jadeDatasetName }}
           - name: RELEASE_DATE
             value: {{ $releaseDate | quote }}
         source: |

--- a/orchestration/templates/dual-writer-cron-workflow.yaml
+++ b/orchestration/templates/dual-writer-cron-workflow.yaml
@@ -28,10 +28,7 @@ spec:
     onExit: {{ if .Values.notification.onlyOnFailure }}send-slack-notification-if-failed{{ else }}send-slack-notification{{ end }}
     templates:
       ##
-      ## Main entry-point to the regularly-run ClinVar ingest workflow.
-      ##
-      ## Delegates to a WorkflowTemplate for all of the business logic,
-      ## to support easily running manual ingests.
+      ## Copy of the base cron-workflow.yaml, substituting in altJade connection info
       ##
       - name: main
         steps:

--- a/orchestration/templates/dual-writer-cron-workflow.yaml
+++ b/orchestration/templates/dual-writer-cron-workflow.yaml
@@ -42,6 +42,8 @@ spec:
                     value: weekly_release/ClinVarVariationRelease_00-latest_weekly.xml.gz
                   - name: gcs-prefix
                     value: {{ include "argo.timestamp" . | quote }}
+                  - name: should-export-diff
+                    value: 'false'
 
       ##
       ## Send a Slack notifcation if the workflow has failed.

--- a/orchestration/templates/dual-writer-cron-workflow.yaml
+++ b/orchestration/templates/dual-writer-cron-workflow.yaml
@@ -82,5 +82,5 @@ spec:
           - -H
           - 'Authorization: Bearer $(OAUTH_TOKEN)'
           - -d
-          - '{"text": "Workflow $(WORKFLOW_ID) in env *$(WORKFLOW_ENV)* entered state: *$(WORKFLOW_STATE)*", "channel": "$(CHANNEL_ID)"}'
+          - '{"text": "(dual writer) Workflow $(WORKFLOW_ID) in env *$(WORKFLOW_ENV)* entered state: *$(WORKFLOW_STATE)*", "channel": "$(CHANNEL_ID)"}'
           - "https://slack.com/api/chat.postMessage"

--- a/orchestration/templates/dual-writer-cron-workflow.yaml
+++ b/orchestration/templates/dual-writer-cron-workflow.yaml
@@ -60,7 +60,7 @@ spec:
           image: curlimages/curl:7.70.0
           env:
             - name: CHANNEL_ID
-              value: {{ .Values.notification.channelId }}
+              value: {{ .Values.notification.altChannelId }}
             - name: WORKFLOW_ID
               value: '{{ "{{workflow.name}}" }}'
             - name: WORKFLOW_STATE

--- a/orchestration/templates/dual-writer-cron-workflow.yaml
+++ b/orchestration/templates/dual-writer-cron-workflow.yaml
@@ -25,6 +25,7 @@ spec:
     serviceAccountName: {{ .Values.serviceAccount.k8sName }}
     podGC:
       strategy: OnWorkflowSuccess
+    onExit: { { if .Values.notification.onlyOnFailure } }send-slack-notification-if-failed{{ else }}send-slack-notification{{ end }}
     templates:
       ##
       ## Main entry-point to the regularly-run ClinVar ingest workflow.
@@ -44,3 +45,43 @@ spec:
                     value: weekly_release/ClinVarVariationRelease_00-latest_weekly.xml.gz
                   - name: gcs-prefix
                     value: {{ include "argo.timestamp" . | quote }}
+
+      ##
+      ## Send a Slack notifcation if the workflow has failed.
+      ##
+      - name: send-slack-notification-if-failed
+        steps:
+          - - name: send-notification
+              template: send-slack-notification
+              when: '{{ "{{workflow.status}} != Succeeded" }}'
+
+      ##
+      ## Send a Slack notification describing the final status of the workflow.
+      ##
+      - name: send-slack-notification
+        container:
+          image: curlimages/curl:7.70.0
+          env:
+            - name: CHANNEL_ID
+              value: {{ .Values.notification.channelId }}
+            - name: WORKFLOW_ID
+              value: '{{ "{{workflow.name}}" }}'
+            - name: WORKFLOW_STATE
+              value: '{{ "{{workflow.status}}" }}'
+            - name: WORKFLOW_ENV
+              value: {{ .Values.jade.environment }}
+            - name: OAUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.notification.oauthToken.secretName }}
+                  key: {{ .Values.notification.oauthToken.secretKey }}
+          command: [curl]
+          args:
+          - -XPOST
+          - -H
+          - 'Content-type: application/json'
+          - -H
+          - 'Authorization: Bearer $(OAUTH_TOKEN)'
+          - -d
+          - '{"text": "Workflow $(WORKFLOW_ID) in env *$(WORKFLOW_ENV)* entered state: *$(WORKFLOW_STATE)*", "channel": "$(CHANNEL_ID)"}'
+          - "https://slack.com/api/chat.postMessage"

--- a/orchestration/templates/dual-writer-cron-workflow.yaml
+++ b/orchestration/templates/dual-writer-cron-workflow.yaml
@@ -25,7 +25,7 @@ spec:
     serviceAccountName: {{ .Values.serviceAccount.k8sName }}
     podGC:
       strategy: OnWorkflowSuccess
-    onExit: { { if .Values.notification.onlyOnFailure } }send-slack-notification-if-failed{{ else }}send-slack-notification{{ end }}
+    onExit: {{ if .Values.notification.onlyOnFailure }}send-slack-notification-if-failed{{ else }}send-slack-notification{{ end }}
     templates:
       ##
       ## Main entry-point to the regularly-run ClinVar ingest workflow.

--- a/orchestration/templates/dual-writer-cron-workflow.yaml
+++ b/orchestration/templates/dual-writer-cron-workflow.yaml
@@ -1,0 +1,45 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: dual-writer-clinvar-ingest
+spec:
+  suspend: {{ not .Values.cron.enable }}
+  schedule: {{ .Values.cron.schedule | quote }}
+  timezone: {{ .Values.cron.timezone | quote }}
+  concurrencyPolicy: Forbid
+  workflowSpec:
+    entrypoint: main
+    arguments:
+      parameters:
+        - name: jade-dataset-id
+          value: FAKE_DATASET_ID
+        - name: jade-dataset-name
+          value: FAKE_DATASET_NAME
+        - name: jade-data-project
+          value: FAKE_DATA_PROJECT_NAME
+        - name: jade-url
+          value: FAKE_URL
+        - name: jade-profile-id
+          value: FAKE_PROFILE_ID
+    serviceAccountName: {{ .Values.serviceAccount.k8sName }}
+    podGC:
+      strategy: OnWorkflowSuccess
+    templates:
+      ##
+      ## Main entry-point to the regularly-run ClinVar ingest workflow.
+      ##
+      ## Delegates to a WorkflowTemplate for all of the business logic,
+      ## to support easily running manual ingests.
+      ##
+      - name: main
+        steps:
+          - - name: run-main-template
+              templateRef:
+                name: ingest-clinvar-release-e2e
+                template: main
+              arguments:
+                parameters:
+                  - name: archive-path
+                    value: weekly_release/ClinVarVariationRelease_00-latest_weekly.xml.gz
+                  - name: gcs-prefix
+                    value: {{ include "argo.timestamp" . | quote }}

--- a/orchestration/templates/dual-writer-cron-workflow.yaml
+++ b/orchestration/templates/dual-writer-cron-workflow.yaml
@@ -12,15 +12,15 @@ spec:
     arguments:
       parameters:
         - name: jade-dataset-id
-          value: FAKE_DATASET_ID
+          value: {{ .Values.altJade.datasetId }}
         - name: jade-dataset-name
-          value: FAKE_DATASET_NAME
+          value: {{ .Values.altJade.datasetName }}
         - name: jade-data-project
-          value: FAKE_DATA_PROJECT_NAME
+          value: {{ .Values.altJade.dataProject }}
         - name: jade-url
-          value: FAKE_URL
+          value: {{ .Values.altJade.url }}
         - name: jade-profile-id
-          value: FAKE_PROFILE_ID
+          value: {{ .Values.altJade.profileId }}
     serviceAccountName: {{ .Values.serviceAccount.k8sName }}
     podGC:
       strategy: OnWorkflowSuccess

--- a/orchestration/templates/dual-writer-cron-workflow.yaml
+++ b/orchestration/templates/dual-writer-cron-workflow.yaml
@@ -1,3 +1,10 @@
+##
+## Copy of the base cron-workflow.yaml, substituting in altJade connection info.
+## This is a temporary flow to dual write clinvar data to a separate dataset in "real" prod
+## to facilitate the overall migration to that environment.
+## Once we have vetted that dataset and all stakeholders are ok to switch, we should remove this
+## flow and switch the primary Jade values to point at the new dataset.
+##
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
@@ -27,9 +34,6 @@ spec:
       strategy: OnWorkflowSuccess
     onExit: {{ if .Values.notification.onlyOnFailure }}send-slack-notification-if-failed{{ else }}send-slack-notification{{ end }}
     templates:
-      ##
-      ## Copy of the base cron-workflow.yaml, substituting in altJade connection info
-      ##
       - name: main
         steps:
           - - name: run-main-template

--- a/orchestration/templates/dual-writer-cron-workflow.yaml
+++ b/orchestration/templates/dual-writer-cron-workflow.yaml
@@ -21,6 +21,7 @@ spec:
           value: {{ .Values.altJade.url }}
         - name: jade-profile-id
           value: {{ .Values.altJade.profileId }}
+
     serviceAccountName: {{ .Values.serviceAccount.k8sName }}
     podGC:
       strategy: OnWorkflowSuccess

--- a/orchestration/templates/export-diff.yaml
+++ b/orchestration/templates/export-diff.yaml
@@ -8,6 +8,8 @@ spec:
   templates:
     {{- $pipelineVersion := default "latest" .Values.version }}
     {{- $versionIsPinned := ne $pipelineVersion "latest" }}
+    {{- $jadeDatasetName := "{{workflow.parameters.jade-dataset-name}}" }}
+
     ##
     ## Entrypoint for notifying clinvar of changes. Does so using Kafka.
     ##
@@ -158,9 +160,9 @@ spec:
         command: [bash]
         env:
           - name: JADE_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: '{{ "{{workflow.parameters.jade-data-project}}" }}'
           - name: JADE_DATASET
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $jadeDatasetName }}
           - name: RELEASE_DATE
             value: {{ $releaseDate | quote }}
         source: |
@@ -194,8 +196,8 @@ spec:
           - name: PROJECT
             value: {{ .Values.staging.bigquery.project }}
           - name: JADE_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value:  '{{ "{{workflow.parameters.jade-data-project}}" }}'
           - name: JADE_DATASET
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $jadeDatasetName }}
         source: |
         {{- include "argo.render-lines" (.Files.Lines "scripts/check-if-processed-today.sh") | indent 10 }}

--- a/orchestration/templates/ingest-clinvar-release-e2e.yaml
+++ b/orchestration/templates/ingest-clinvar-release-e2e.yaml
@@ -45,10 +45,8 @@ spec:
                 - name: gcs-prefix
                   value: {{ $gcsPrefix | quote }}
             {{- $datasetName := "{{tasks.process-archive.outputs.parameters.dataset-name}}" }}
-          {{- $shouldExportDiff := printf "%t" .Values.steps.exportDiff.enabled }}
 
           - name: export-diff
-            when: {{ printf "%s == true" $shouldExportDiff }}
             dependencies: [process-archive]
             templateRef:
               name: export-diff

--- a/orchestration/templates/ingest-clinvar-release-e2e.yaml
+++ b/orchestration/templates/ingest-clinvar-release-e2e.yaml
@@ -19,6 +19,8 @@ spec:
           {{- $archivePath := "{{inputs.parameters.archive-path}}" }}
           - name: gcs-prefix
           {{- $gcsPrefix := "{{inputs.parameters.gcs-prefix}}" }}
+          - name: should-export-diff
+          {{- $shouldExportDiff := "{{inputs.parameters.should-export-diff}}" }}
       dag:
         tasks:
           - name: ingest-archive
@@ -47,6 +49,7 @@ spec:
             {{- $datasetName := "{{tasks.process-archive.outputs.parameters.dataset-name}}" }}
 
           - name: export-diff
+            when: {{ $shouldExportDiff | quote }}
             dependencies: [process-archive]
             templateRef:
               name: export-diff

--- a/orchestration/templates/ingest-xml-archive.yaml
+++ b/orchestration/templates/ingest-xml-archive.yaml
@@ -256,13 +256,13 @@ spec:
             arguments:
               parameters:
                 {{- $gcsFilePath := printf "%s/xml/%s" $gcsPrefix (include "clinvar.raw-archive-name" .) | quote }}
-                {{- with .Values.jade }}
                 - name: url
                   value: '{{ "{{workflow.parameters.jade-url}}" }}'
                 - name: dataset-id
                   value: '{{ "{{workflow.parameters.jade-dataset-id}}" }}'
                 - name: profile-id
                   value: '{{ "{{workflow.parameters.jade-profile-id}}" }}'
+                {{- with .Values.jade }}
                 - name: timeout
                   value: {{ .pollTimeout }}
                 - name: sa-secret
@@ -336,12 +336,12 @@ spec:
                   value: {{ .Values.staging.gcsBucket }}
                 - name: gcs-prefix
                   value: {{ $jsonPrefix | quote }}
-                {{- with .Values.jade }}
                 - name: url
                   value: '{{ "{{workflow.parameters.jade-url}}" }}'
                 - name: dataset-id
                   value: '{{ "{{workflow.parameters.jade-dataset-id}}" }}'
                 - name: timeout
+                {{- with .Values.jade }}
                   value: {{ .pollTimeout }}
                 - name: sa-secret
                   value: {{ .accessKey.secretName }}

--- a/orchestration/templates/ingest-xml-archive.yaml
+++ b/orchestration/templates/ingest-xml-archive.yaml
@@ -146,6 +146,7 @@ spec:
     ##
     ## Check if a row exists in the xml_archive table for a given release date.
     ##
+   {{- $jadeDatasetName := "{{workflow.parameters.jade-dataset-name}}" }}
     - name: check-for-existing-release
       inputs:
         parameters:
@@ -157,9 +158,9 @@ spec:
           - name: PROJECT
             value: {{ .Values.staging.bigquery.project }}
           - name: JADE_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: '{{ "{{workflow.parameters.jade-data-project}}" }}'
           - name: JADE_DATASET
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $jadeDatasetName }}
           - name: RELEASE_DATE
             value: {{ $releaseDate | quote }}
           - name: PROPERTY
@@ -196,11 +197,11 @@ spec:
                   value: {{ $targetPath | quote }}
                 {{- with .Values.jade }}
                 - name: url
-                  value: {{ .url }}
+                  value: '{{ "{{workflow.parameters.jade-url}}" }}'
                 - name: dataset-id
-                  value: {{ .datasetId }}
+                  value: '{{ "{{workflow.parameters.jade-dataset-id}}" }}'
                 - name: profile-id
-                  value: {{ .profileId }}
+                  value: '{{ "{{workflow.parameters.jade-profile-id}}" }}'
                 - name: sa-secret
                   value: {{ .accessKey.secretName }}
                 - name: sa-secret-key
@@ -257,11 +258,11 @@ spec:
                 {{- $gcsFilePath := printf "%s/xml/%s" $gcsPrefix (include "clinvar.raw-archive-name" .) | quote }}
                 {{- with .Values.jade }}
                 - name: url
-                  value: {{ .url }}
+                  value: '{{ "{{workflow.parameters.jade-url}}" }}'
                 - name: dataset-id
-                  value: {{ .datasetId }}
+                  value: '{{ "{{workflow.parameters.jade-dataset-id}}" }}'
                 - name: profile-id
-                  value: {{ .profileId }}
+                  value: '{{ "{{workflow.parameters.jade-profile-id}}" }}'
                 - name: timeout
                   value: {{ .pollTimeout }}
                 - name: sa-secret
@@ -337,9 +338,9 @@ spec:
                   value: {{ $jsonPrefix | quote }}
                 {{- with .Values.jade }}
                 - name: url
-                  value: {{ .url }}
+                  value: '{{ "{{workflow.parameters.jade-url}}" }}'
                 - name: dataset-id
-                  value: {{ .datasetId }}
+                  value: '{{ "{{workflow.parameters.jade-dataset-id}}" }}'
                 - name: timeout
                   value: {{ .pollTimeout }}
                 - name: sa-secret

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -8,6 +8,7 @@ spec:
   templates:
     {{- $pipelineVersion := default "latest" .Values.version }}
     {{- $versionIsPinned := ne $pipelineVersion "latest" }}
+    {{- $jadeDatasetName := "{{workflow.parameters.jade-dataset-name}}" }}
 
     ##
     ## Entrypoint for processing a ClinVar archive.
@@ -209,9 +210,9 @@ spec:
                 - name: staging-bq-dataset
                   value: {{ $datasetName | quote }}
                 - name: jade-bq-project
-                  value: {{ .Values.jade.dataProject }}
+                  value: '{{ "{{workflow.parameters.jade-data-project}}" }}'
                 - name: jade-bq-dataset
-                  value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+                  value: {{ printf "datarepo_%s" $jadeDatasetName }}
                 - name: upsert
                   value: 'false'
                 - name: diff-full-history
@@ -239,7 +240,7 @@ spec:
                   value: {{ .Values.staging.gcsBucket }}
                 {{- with .Values.jade }}
                 - name: url
-                  value: {{ .url }}
+                  value: '{{ "{{workflow.parameters.jade-dataset-url}}" }}'
                 - name: dataset-id
                   value: '{{ "{{workflow.parameters.jade-dataset-id}}" }}'
                 - name: timeout
@@ -267,7 +268,7 @@ spec:
                   value: {{ $newRowsPrefix | quote }}
                 {{- with .Values.jade }}
                 - name: url
-                  value: {{ .url }}
+                  value: '{{ "{{workflow.parameters.jade-url}}" }}'
                 - name: dataset-id
                   value: '{{ "{{workflow.parameters.jade-dataset-id}}" }}'
                 - name: timeout
@@ -295,11 +296,11 @@ spec:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: {{ printf "/secret/%s" .Values.jade.accessKey.secretKey }}
           - name: REPO_DATA_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: '{{ "{{workflow.parameters.jade-data-project}}" }}'
           - name: REPO_DATASET_NAME
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $jadeDatasetName }}
           - name: REPO_HOST
-            value: {{ .Values.jade.url }}
+            value: '{{ "{{workflow.parameters.jade-url}}" }}'
           - name: REPO_DATASET_ID
             value: '{{ "{{workflow.parameters.jade-dataset-id}}" }}'
         command: ["python", "-c", "import check; check.run()"]
@@ -360,9 +361,9 @@ spec:
               parameters:
                 - name: job-id
                   value: {{ $jobId | quote }}
-                {{- with .Values.jade }}
                 - name: api-url
-                  value: {{ .url }}
+                  value: '{{ "{{workflow.parameters.jade-url}}" }}'
+                {{- with .Values.jade }}
                 - name: timeout
                   value: {{ .pollTimeout }}
                 - name: sa-secret
@@ -386,9 +387,9 @@ spec:
           - name: PROJECT
             value: {{ .Values.staging.bigquery.project }}
           - name: JADE_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: '{{ "{{workflow.parameters.jade-data-project}}" }}'
           - name: JADE_DATASET
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $jadeDatasetName }}
           - name: RELEASE_DATE
             value: {{ $releaseDate | quote }}
           - name: VERSION
@@ -439,11 +440,11 @@ spec:
             mountPath: /secret
         env:
           - name: API_URL
-            value: {{ .url }}
+            value: '{{ "{{workflow.parameters.jade-url}}" }}'
           - name: DATASET_NAME
-            value: {{ .datasetName }}
+            value: '{{ "{{workflow.parameters.jade-dataset-name}}" }}'
           - name: PROFILE_ID
-            value: {{ .profileId }}
+            value: '{{ "{{workflow.parameters.jade-profile-id}}" }}'
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: {{ printf "/secret/%s" .accessKey.secretKey }}
           - name: ASSET_NAME

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -241,7 +241,7 @@ spec:
                 - name: url
                   value: {{ .url }}
                 - name: dataset-id
-                  value: {{ .datasetId }}
+                  value: '{{ "{{workflow.parameters.jade-dataset-id}}" }}'
                 - name: timeout
                   value: {{ .pollTimeout }}
                 - name: sa-secret
@@ -269,7 +269,7 @@ spec:
                 - name: url
                   value: {{ .url }}
                 - name: dataset-id
-                  value: {{ .datasetId }}
+                  value: '{{ "{{workflow.parameters.jade-dataset-id}}" }}'
                 - name: timeout
                   value: {{ .pollTimeout }}
                 - name: sa-secret
@@ -301,7 +301,7 @@ spec:
           - name: REPO_HOST
             value: {{ .Values.jade.url }}
           - name: REPO_DATASET_ID
-            value: {{ .Values.jade.datasetId }}
+            value: '{{ "{{workflow.parameters.jade-dataset-id}}" }}'
         command: ["python", "-c", "import check; check.run()"]
 
     ##

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -240,7 +240,7 @@ spec:
                   value: {{ .Values.staging.gcsBucket }}
                 {{- with .Values.jade }}
                 - name: url
-                  value: '{{ "{{workflow.parameters.jade-dataset-url}}" }}'
+                  value: '{{ "{{workflow.parameters.jade-url}}" }}'
                 - name: dataset-id
                   value: '{{ "{{workflow.parameters.jade-dataset-id}}" }}'
                 - name: timeout

--- a/orchestration/templates/process-xml-release.yaml
+++ b/orchestration/templates/process-xml-release.yaml
@@ -6,6 +6,8 @@ spec:
   entrypoint: main
   serviceAccountName: {{ .Values.serviceAccount.k8sName }}
   templates:
+    {{- $jadeDatasetName := "{{workflow.parameters.jade-dataset-name}}" }}
+
     ##
     ## Convert a ClinVar archive from XML to JSON, then process it with Dataflow.
     ##
@@ -176,9 +178,9 @@ spec:
           - name: PROJECT
             value: {{ .Values.staging.bigquery.project }}
           - name: JADE_PROJECT
-            value: {{ .Values.jade.dataProject }}
+            value: '{{ "{{workflow.parameters.jade-data-project}}" }}'
           - name: JADE_DATASET
-            value: {{ printf "datarepo_%s" .Values.jade.datasetName }}
+            value: {{ printf "datarepo_%s" $jadeDatasetName }}
           - name: PROPERTY
             value: archive_path
         command: [bash]
@@ -206,9 +208,9 @@ spec:
             mountPath: /secret
         env:
           - name: API_URL
-            value: {{ .Values.jade.url }}
+            value: '{{ "{{workflow.parameters.jade-url}}" }}'
           - name: DATASET_ID
-            value: {{ .Values.jade.datasetId }}
+            value: '{{ "{{workflow.parameters.jade-dataset-id}}" }}'
           - name: FILE_ID
             value: {{ $archiveId | quote }}
           - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/orchestration/values.schema.json
+++ b/orchestration/values.schema.json
@@ -126,17 +126,6 @@
         }
       },
       "required": ["gcsBucket", "kafka"]
-    },
-    "steps": {
-      "type": "object",
-      "properties": {
-        "exportDiffs": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type":  "boolean" }
-          }
-        }
-      }
     }
   },
   "required": ["parallelism", "staging", "jade", "serviceAccount",


### PR DESCRIPTION
The original approach for dual writing was going to be to create a new "clinvar-real-prod" deployment in monster-deploy. This has proven to not be workable.

The alternative approach implemented in this PR is to parameterize the Jade connection information at the top of the workflow and have that flow into all downstream templates. This PR adds a new "dual-writer" cron workflow that is a copy of the existing cron-workflow, but wiring in "alternate" jade connection values (i.e., real prod connection values).

NOTE: This is an updated version of #99 ; instead of adding the jade connection info as parameters to all templates, I've taken a "middle path" approach of making them workflow global vars and changed the helm jade values references to workflow param references in-place. I think this is less risky at the expense of still having some global state.