### PR TITLE
Parameterize channel ID

### DIFF
--- a/orchestration/templates/cron-workflow.yaml
+++ b/orchestration/templates/cron-workflow.yaml
@@ -21,6 +21,8 @@ spec:
           value: {{ .Values.jade.url }}
         - name: jade-profile-id
           value: {{ .Values.jade.profileId }}
+        - name: channel-id
+          value: {{ .Values.notification.channelId }}
 
     serviceAccountName: {{ .Values.serviceAccount.k8sName }}
     podGC:

--- a/orchestration/templates/dual-writer-cron-workflow.yaml
+++ b/orchestration/templates/dual-writer-cron-workflow.yaml
@@ -28,6 +28,8 @@ spec:
           value: {{ .Values.altJade.url }}
         - name: jade-profile-id
           value: {{ .Values.altJade.profileId }}
+        - name: channel-id
+          value: {{ .Values.notification.altChannelId }}
 
     serviceAccountName: {{ .Values.serviceAccount.k8sName }}
     podGC:

--- a/orchestration/templates/ingest-xml-archive.yaml
+++ b/orchestration/templates/ingest-xml-archive.yaml
@@ -378,7 +378,7 @@ spec:
         image: curlimages/curl:7.70.0
         env:
           - name: CHANNEL_ID
-            value: {{ .Values.notification.channelId }}
+            value: '{{ "{{workflow.channelId}}" }}'
           - name: WORKFLOW_ID
             value: '{{ "{{workflow.name}}" }}'
           - name: WORKFLOW_STATE

--- a/orchestration/templates/process-and-reingest-release.yaml
+++ b/orchestration/templates/process-and-reingest-release.yaml
@@ -472,7 +472,7 @@ spec:
         image: curlimages/curl:7.70.0
         env:
           - name: CHANNEL_ID
-            value: {{ .Values.notification.channelId }}
+            value: '{{ "{{workflow.channelId}}" }}'
           - name: WORKFLOW_ID
             value: '{{ "{{workflow.name}}" }}'
           - name: WORKFLOW_STATE


### PR DESCRIPTION
There are a few other slack notifications that need channel ID parameteried. This PR pushes the channel ID to a global workflow var and updates the related templates.
