### PR TITLE
Do not download archive from TDR

### DIFF
--- a/orchestration/templates/ingest-xml-archive.yaml
+++ b/orchestration/templates/ingest-xml-archive.yaml
@@ -61,9 +61,30 @@ spec:
                 - name: cpu
                   value: 1000m
 
+          - name: copy-archive-to-gcs-staging-area
+            dependencies: [download-archive]
+            templateRef:
+              name: {{ .Values.argoTemplates.copyToGCS.name }}
+              template: main
+            arguments:
+              parameters:
+                - name: pvc-name
+                  value: {{ $downloadPvc | quote }}
+                - name: local-path
+                  value: {{ include "clinvar.raw-archive-name" . }}
+                - name: gcs-bucket
+                  value: {{ .Values.staging.gcsBucket }}
+                - name: gcs-path
+                  value: {{ printf "%s/xml/" $gcsPrefix | quote }}
+                - name: memory
+                  value: 1Gi
+                - name: cpu
+                  value: 1000m
+
+
           # Extract the archive's release date so we can check if it's already been ingested.
           - name: extract-release-date
-            dependencies: [download-archive]
+            dependencies: [copy-archive-to-gcs-staging-area]
             template: extract-release-date
             arguments:
               parameters:
@@ -224,30 +245,8 @@ spec:
                 - name: gcs-prefix
                   value: {{ $gcsPrefix | quote }}
 
-          # If we haven't already ingested a file, upload the archive and ingest it.
-          - name: upload-archive
-            dependencies: [check-for-existing-file]
-            when: {{ $shouldIngestFile | quote }}
-            templateRef:
-              name: {{ .Values.argoTemplates.copyToGCS.name }}
-              template: main
-            arguments:
-              parameters:
-                - name: pvc-name
-                  value: {{ $pvcName | quote }}
-                - name: local-path
-                  value: {{ include "clinvar.raw-archive-name" . }}
-                - name: gcs-bucket
-                  value: {{ .Values.staging.gcsBucket }}
-                - name: gcs-path
-                  value: {{ printf "%s/xml/" $gcsPrefix | quote }}
-                - name: memory
-                  value: 1Gi
-                - name: cpu
-                  value: 1000m
-
           - name: ingest-archive
-            dependencies: [check-for-existing-file, upload-archive]
+            dependencies: [check-for-existing-file]
             when: {{ $shouldIngestFile | quote }}
             onExit: send-slack-notification
             templateRef:

--- a/orchestration/templates/process-xml-release.yaml
+++ b/orchestration/templates/process-xml-release.yaml
@@ -20,24 +20,24 @@ spec:
           {{- $gcsPrefix := "{{inputs.parameters.gcs-prefix}}" }}
       dag:
         tasks:
-          # Get the file ID of the raw XML.
-          - name: get-archive-id
-            template: get-archive-id
-            arguments:
-              parameters:
-                - name: release-date
-                  value: {{ $releaseDate | quote }}
-            {{- $archiveId := "{{tasks.get-archive-id.outputs.result}}" }}
-
-          # Use the archive's ID to get its gs:// path.
-          - name: get-archive-uri
-            dependencies: [get-archive-id]
-            template: lookup-archive-path
-            arguments:
-              parameters:
-                - name: archive-id
-                  value: {{ $archiveId | quote }}
-            {{- $archivePath := "{{tasks.get-archive-uri.outputs.result}}" }}
+#          # Get the file ID of the raw XML.
+#          - name: get-archive-id
+#            template: get-archive-id
+#            arguments:
+#              parameters:
+#                - name: release-date
+#                  value: {{ $releaseDate | quote }}
+#            {{- $archiveId := "{{tasks.get-archive-id.outputs.result}}" }}
+#
+#          # Use the archive's ID to get its gs:// path.
+#          - name: get-archive-uri
+#            dependencies: [get-archive-id]
+#            template: lookup-archive-path
+#            arguments:
+#              parameters:
+#                - name: archive-id
+#                  value: {{ $archiveId | quote }}
+#            {{- $archivePath := "{{tasks.get-archive-uri.outputs.result}}" }}
 
           # Generate a PVC to hold the raw XML.
           - name: generate-download-volume
@@ -53,10 +53,11 @@ spec:
                 - name: storage-class
                   value: {{ .Values.volumes.storageClass }}
             {{- $downloadPvc := "{{tasks.generate-download-volume.outputs.parameters.pvc-name}}" }}
+            {{- $archiveGcsPath := "{{ .Values.staging.gcsBucket }}/{{ $gcsPrefix }}/xml" }}
 
           # Download the raw XML from the dataset's bucket.
           - name: download-archive
-            dependencies: [get-archive-uri, generate-download-volume]
+            dependencies: [generate-download-volume]
             template: download-gcs-file
             arguments:
               parameters:
@@ -65,7 +66,7 @@ spec:
                 - name: local-path
                   value: {{ include "clinvar.raw-archive-name" . }}
                 - name: gcs-path
-                  value: {{ $archivePath | quote }}
+                  value:  {{ $archiveGcsPath | quote }} # {{ .Values.staging.gcsBucket }}  # {{ $archivePath | quote }}
 
           # Generate a PVC to hold extracted JSON-list files.
           - name: generate-extraction-volume

--- a/orchestration/templates/process-xml-release.yaml
+++ b/orchestration/templates/process-xml-release.yaml
@@ -47,7 +47,7 @@ spec:
                 - name: local-path
                   value: {{ include "clinvar.raw-archive-name" . }}
                 - name: gcs-path
-                  value:  {{ $archiveGcsPath }} # {{ .Values.staging.gcsBucket }}  # {{ $archivePath | quote }}
+                  value:  {{ $archiveGcsPath }}
 
           # Generate a PVC to hold extracted JSON-list files.
           - name: generate-extraction-volume

--- a/orchestration/templates/process-xml-release.yaml
+++ b/orchestration/templates/process-xml-release.yaml
@@ -53,7 +53,7 @@ spec:
                 - name: storage-class
                   value: {{ .Values.volumes.storageClass }}
             {{- $downloadPvc := "{{tasks.generate-download-volume.outputs.parameters.pvc-name}}" }}
-            {{- $archiveGcsPath := "{{ .Values.staging.gcsBucket }}/{{ $gcsPrefix }}/xml" }}
+            {{- $archiveGcsPath := printf "%s/%s/xml" .Values.staging.gcsBucket $gcsPrefix }}
 
           # Download the raw XML from the dataset's bucket.
           - name: download-archive

--- a/orchestration/templates/process-xml-release.yaml
+++ b/orchestration/templates/process-xml-release.yaml
@@ -53,7 +53,7 @@ spec:
                 - name: storage-class
                   value: {{ .Values.volumes.storageClass }}
             {{- $downloadPvc := "{{tasks.generate-download-volume.outputs.parameters.pvc-name}}" }}
-            {{- $archiveGcsPath := printf "gs://%s/%s/xml" .Values.staging.gcsBucket $gcsPrefix }}
+            {{- $archiveGcsPath := printf "gs://%s/%s/xml/%s" .Values.staging.gcsBucket $gcsPrefix (include "clinvar.raw-archive-name" .) }}
 
           # Download the raw XML from the dataset's bucket.
           - name: download-archive

--- a/orchestration/templates/process-xml-release.yaml
+++ b/orchestration/templates/process-xml-release.yaml
@@ -66,7 +66,7 @@ spec:
                 - name: local-path
                   value: {{ include "clinvar.raw-archive-name" . }}
                 - name: gcs-path
-                  value:  {{ $archiveGcsPath | quote }} # {{ .Values.staging.gcsBucket }}  # {{ $archivePath | quote }}
+                  value:  {{ $archiveGcsPath }} # {{ .Values.staging.gcsBucket }}  # {{ $archivePath | quote }}
 
           # Generate a PVC to hold extracted JSON-list files.
           - name: generate-extraction-volume

--- a/orchestration/templates/process-xml-release.yaml
+++ b/orchestration/templates/process-xml-release.yaml
@@ -20,25 +20,6 @@ spec:
           {{- $gcsPrefix := "{{inputs.parameters.gcs-prefix}}" }}
       dag:
         tasks:
-#          # Get the file ID of the raw XML.
-#          - name: get-archive-id
-#            template: get-archive-id
-#            arguments:
-#              parameters:
-#                - name: release-date
-#                  value: {{ $releaseDate | quote }}
-#            {{- $archiveId := "{{tasks.get-archive-id.outputs.result}}" }}
-#
-#          # Use the archive's ID to get its gs:// path.
-#          - name: get-archive-uri
-#            dependencies: [get-archive-id]
-#            template: lookup-archive-path
-#            arguments:
-#              parameters:
-#                - name: archive-id
-#                  value: {{ $archiveId | quote }}
-#            {{- $archivePath := "{{tasks.get-archive-uri.outputs.result}}" }}
-
           # Generate a PVC to hold the raw XML.
           - name: generate-download-volume
             templateRef:

--- a/orchestration/templates/process-xml-release.yaml
+++ b/orchestration/templates/process-xml-release.yaml
@@ -53,7 +53,7 @@ spec:
                 - name: storage-class
                   value: {{ .Values.volumes.storageClass }}
             {{- $downloadPvc := "{{tasks.generate-download-volume.outputs.parameters.pvc-name}}" }}
-            {{- $archiveGcsPath := printf "%s/%s/xml" .Values.staging.gcsBucket $gcsPrefix }}
+            {{- $archiveGcsPath := printf "gs://%s/%s/xml" .Values.staging.gcsBucket $gcsPrefix }}
 
           # Download the raw XML from the dataset's bucket.
           - name: download-archive


### PR DESCRIPTION
We cannot download an archive from TDR unless it has been included in a snapshot, which does not take place until the _end_ of the ingest. This always worked on our legacy dataset because the argo runner was given permissions ad-hoc, but we will not have these permissions in our new dataset.

So, we need to store the archive in our GCS staging area at the beginning of the ingest and stop pulling it down from TDR.
