### PR TITLE
Retry archive upload on failure

### DIFF
--- a/orchestration/templates/process-xml-release.yaml
+++ b/orchestration/templates/process-xml-release.yaml
@@ -102,6 +102,7 @@ spec:
 
           # Upload extracted JSON-list data to GCS.
           - name: upload-extracted-archive
+            {{ - include "argo.retry" . | indent 6 }}
             dependencies: [extract-xml]
             templateRef:
               name: {{ .Values.argoTemplates.gsutilRsync.name }}

--- a/orchestration/templates/process-xml-release.yaml
+++ b/orchestration/templates/process-xml-release.yaml
@@ -102,7 +102,7 @@ spec:
 
           # Upload extracted JSON-list data to GCS.
           - name: upload-extracted-archive
-            {{ - include "argo.retry" . | indent 6 }}
+            {{- include "argo.retry" . | indent 6 }}
             dependencies: [extract-xml]
             templateRef:
               name: {{ .Values.argoTemplates.gsutilRsync.name }}


### PR DESCRIPTION
Our last run failed due to a 503 from GCS during an upload. These are retryable errors so we should mark the Argo step as retryable. 