### PR TITLE
Retry on error when pulling data from GCS

### DIFF
--- a/orchestration/templates/process-xml-release.yaml
+++ b/orchestration/templates/process-xml-release.yaml
@@ -207,6 +207,7 @@ spec:
     ## NOTE: This is generic, we should move it to monster-helm.
     ##
     - name: download-gcs-file
+      {{- include "argo.retry" . | indent 6 }}
       inputs:
         parameters:
           - name: pvc-name


### PR DESCRIPTION
We had a job fail when pulling the archive from GCS to the local volume  due to a 404 from GCS. Assuming this is a transient GCS issue we should retry a few times before giving up.