### PR TITLE
Dedupe on trait mappings

### DIFF
--- a/transformation/src/main/scala/org/broadinstitute/monster/clinvar/ArchiveBranches.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/clinvar/ArchiveBranches.scala
@@ -133,7 +133,7 @@ object ArchiveBranches extends PipelineCoders {
       scvTraits = sideCtx(scvTraitOut),
       traitSets = latestTraitSets,
       traits = latestTraits,
-      traitMappings = sideCtx(traitMappingOut)
+      traitMappings = sideCtx(traitMappingOut).distinct
     )
   }
 

--- a/transformation/src/test/scala/org/broadinstitute/monster/clinvar/ArchiveBranchesSpec.scala
+++ b/transformation/src/test/scala/org/broadinstitute/monster/clinvar/ArchiveBranchesSpec.scala
@@ -170,6 +170,91 @@ class ArchiveBranchesSpec extends PipelineSpec with PipelineCoders {
     out should contain theSameElementsAs expected
   }
 
+  it should "dedup trait mappings" in {
+    val date = LocalDate.of(2020, 6, 23)
+
+    def parse(id: String) =
+      VCV(
+        variation = Variation(
+          variation = JadeVariation.init(id, date, "type"),
+          genes = Nil,
+          associations = Nil
+        ),
+        vcv = None,
+        rcvs = Nil,
+        traitSets = Nil,
+        traits = Nil,
+        traitMappings = List(
+          TraitMapping(
+            clinicalAssertionId = "dupe_assertion_id",
+            mappingType = "dupe_mapping_type",
+            traitType = "dupe_trait_type",
+            mappingRef = "dupe_mapping_ref",
+            mappingValue = "dupe_mapping_value",
+            releaseDate = date,
+            medgenId = Some("dupe_medgen_id"),
+            medgenName = Some("dupe_medgen_name")
+          ),
+          TraitMapping(
+            clinicalAssertionId = "dupe_assertion_id",
+            mappingType = "dupe_mapping_type",
+            traitType = "dupe_trait_type",
+            mappingRef = "dupe_mapping_ref",
+            mappingValue = "dupe_mapping_value",
+            releaseDate = date,
+            medgenId = Some("dupe_medgen_id"),
+            medgenName = Some("dupe_medgen_name")
+          ),
+          TraitMapping(
+            clinicalAssertionId = "example_assertion_id",
+            mappingType = "example_mapping_type",
+            traitType = "example_trait_type",
+            mappingRef = "example_mapping_ref",
+            mappingValue = "example_mapping_value_1",
+            releaseDate = date,
+            medgenId = Some("example_medgen_id_1"),
+            medgenName = Some("example_medgen_name")
+          )
+        ),
+        scvs = Nil
+      )
+
+    val fakeParser: VCV.Parser = rawArchive => {
+      val id = rawArchive.read[String]("id")
+      parse(id)
+    }
+    val archiveCount = 10
+    val in = List.tabulate[Msg](archiveCount) { i =>
+      Obj(ArchiveBranches.ArchiveKey -> Obj(Str("id") -> Str(i.toString)))
+    }
+    val expected = List(
+      TraitMapping(
+        clinicalAssertionId = "dupe_assertion_id",
+        mappingType = "dupe_mapping_type",
+        traitType = "dupe_trait_type",
+        mappingRef = "dupe_mapping_ref",
+        mappingValue = "dupe_mapping_value",
+        releaseDate = date,
+        medgenId = Some("dupe_medgen_id"),
+        medgenName = Some("dupe_medgen_name")
+      ),
+      TraitMapping(
+        clinicalAssertionId = "example_assertion_id",
+        mappingType = "example_mapping_type",
+        traitType = "example_trait_type",
+        mappingRef = "example_mapping_ref",
+        mappingValue = "example_mapping_value_1",
+        releaseDate = date,
+        medgenId = Some("example_medgen_id_1"),
+        medgenName = Some("example_medgen_name")
+      )
+    )
+
+    val out = runWithData(in)(ArchiveBranches.fromArchiveStream(fakeParser, _).traitMappings)
+
+    out should contain theSameElementsAs expected
+  }
+
   it should "dedup submissions by date" in {
     val date = LocalDate.of(2020, 6, 23)
 


### PR DESCRIPTION
We are creating duplicate entries in the `trait_mapping` table. We should distinct on the list of `trait_mappings` prior to outputting the JSON to GCS for ingest to TDR.